### PR TITLE
Add option to show full .Content on home page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ baseURL = "http://en.xianmin.org/hugo-theme-jane/"
 title = "Jane - A simple theme for Hugo"
 enableRobotsTXT = true
 enableEmoji = true
-# theme = "jane"
+theme = "jane"
 
 # language support en / zh-cn / other... translations present in i18n/
 defaultContentLanguage = "en"  # Default language to use (if you setup multilingual support)
@@ -49,6 +49,7 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
   debug = false             # If true, load `eruda.min.js`. See https://github.com/liriliri/eruda
 
   since = "2017"            # Site creation time          # 站点建立时间
+  homeFullContent = false   # if false, show post summaries on home page. Othewise show full content.
   rssFullContent = true     # if false, Rss feed instead of the summary
 
   # site info (optional)                                  # 站点信息（可选，不需要的可以直接注释掉）

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -18,11 +18,17 @@
   </header>
   <!-- Content -->
   <div class="post-content">
-    <div class="post-summary">
-      {{ .Summary }}
-    </div>
-    <div class="read-more">
-      <a href="{{ .URL }}" class="read-more-link">{{ i18n "readmore" }}</a>
-    </div>
+      {{ if .Site.Params.homeFullContent }}
+      <div class="post-summary">
+        {{ .Content }}
+      </div>
+      {{ else }}
+      <div class="post-summary">
+        {{ .Summary }}
+      </div>
+      <div class="read-more">
+        <a href="{{ .URL }}" class="read-more-link">{{ i18n "readmore" }}</a>
+      </div>
+    {{ end }}
   </div>
 </article>


### PR DESCRIPTION
Adds new Site Parameter "homeFullContent" which, when true, uses .Content
rather than .Summary while rending posts on the home page.

It's a little odd to render .Content from a template named summary.html but this was the most concise way I could think of.