### PR TITLE
修复启用uglyURLs时terms url 问题

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -28,7 +28,7 @@ Jane 是一个专注于阅读体验的 Hugo 主题。最早的版本基于 [hugo
 
 ### 1. 快速安装 Hugo
 
-从 [Hugo Releases][https://github.com/gohugoio/hugo/releases] 上直接下载安装适合你的版本。
+从 [Hugo Releases](https://github.com/gohugoio/hugo/releases) 上直接下载安装适合你的版本。
 
 
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -49,9 +49,10 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
   weight = 50
   url = "https://gohugo.io"
 
+uglyURLs = false 
 [params]
   debug = false             # If true, load `eruda.min.js`. See https://github.com/liriliri/eruda
-
+  uglyURLs = false          # You must set true after use uglyURLs in site (above). because $.Site.UglyURLs can not import.
   since = "2017"            # Site creation time          # 站点建立时间
   homeFullContent = false   # if false, show post summaries on home page. Othewise show full content.
   rssFullContent = true     # if false, Rss feed instead of the summary

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -60,8 +60,8 @@
         {{ $count := len $taxonomy.Pages }}
         {{ $weigth := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
         {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weigth) ) }}
-        <!--Current font size: {{$currentFontSize}}-->
-        <a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}/" style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{ $name }}</a>
+        <!--Current font size: {{$currentFontSize}}-->   
+        <a href="/tags/{{ $name | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}" style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{ $name }}</a>
       {{ end }}
       </div>
     </div>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -12,7 +12,7 @@
         </div>
           <div class="collection-title">
             <h2 class="archive-year">
-              <a href="{{ $name | urlize | relURL }}/{{ $value.Term | urlize }}/">
+              <a href="{{ $name | urlize | relURL }}/{{ $value.Term | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}">
                 {{ i18n "category" }}{{ $value.Term }}
               </a>
             </h2>
@@ -32,7 +32,7 @@
           {{- end -}}
           {{ if gt (len $value.Pages) 5 }}
             <div class="more-post">
-              <a href="{{ $name | urlize | relURL }}/{{ $value.Term | urlize }}/" class="more-post-link">{{ i18n "morePost" }}</a>
+              <a href="{{ $name | urlize | relURL }}/{{ $value.Term | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}" class="more-post-link">{{ i18n "morePost" }}</a>
             </div>
           {{- end -}}
       </section>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,16 @@
 
 <meta name="renderer" content="webkit" />
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
+{{/* support older feature phones 
+  see: https://stackoverflow.com/questions/1988499/meta-tags-for-mobile-should-they-be-used
+  */}}
+<meta name="MobileOptimized" content="width"/>
+<meta name="HandheldFriendly" content="true"/>
 
+{{/* fit for browsing on mobile devices and PC, 
+  see : https://ziyuan.baidu.com/college/courseinfo?id=156
+*/}}
+<meta name="applicable-device" content="pc,mobile">
 <meta http-equiv="Cache-Control" content="no-transform" />
 <meta http-equiv="Cache-Control" content="no-siteapp" />
 
@@ -10,6 +19,8 @@
 <meta name="msapplication-navbutton-color" content="#f8f5ec">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="#f8f5ec">
+{{/* Add to homescreen for Chrome on Android */}}
+<meta name="mobile-web-app-capable" content="yes">
 
 <!-- author & description & keywords  -->
 <meta name="author" content="{{ if .Params.author }}{{ .Params.author | safeHTML }}{{ else }}{{ .Site.Author.name | safeHTML }}{{ end }}" />

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -39,7 +39,7 @@
       {{ with .Params.tags -}}
         <div class="post-tags">
           {{ range . }}
-          <a href="{{ "tags" | relURL }}/{{ . | urlize }}/">{{ . }}</a>
+          <a href="{{ "tags" | relURL }}/{{ . | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}">{{ . }}</a>
           {{ end }}
         </div>
       {{- end }}


### PR DESCRIPTION
在启用 uglyURLs  后，实际上tag和category的地址由：http://localhsot/tag/ 变成了 http://localhsot/tag.html

可主题中尚未处理，而同时Hugo本身无法将uglyURLs配置作为Site变量公开，所以只能折中使用添加自定义配置形式：
```toml
uglyURLs = true
[params]
     uglyURLs = true
```