### PR TITLE
[Proposal] Show list of available translations

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -80,3 +80,9 @@
 # other
 - id: morePost
   translation: "More Post >>>"
+
+- id: read_ru
+  translation: Читать на русском
+
+- id: read_es
+  translation: Leer en español

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -80,3 +80,9 @@
 # other
 - id: morePost
   translation: "Mas Posts >>>"
+
+- id: read_en
+  translation: Read in English
+
+- id: read_ru
+  translation: Читать на русском

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -80,3 +80,9 @@
 # other
 - id: morePost
   translation: "Больше записей >>>"
+
+- id: read_en
+  translation: Read in English
+
+- id: read_es
+  translation: Leer en español

--- a/layouts/partials/post/i18nlist.html
+++ b/layouts/partials/post/i18nlist.html
@@ -1,3 +1,5 @@
-{{ range .Translations }}
-    <div><a href="{{ .Permalink }}">{{ i18n (printf "read_%s" .Lang) }}: {{ .Title }}</a></div>
+{{ if .IsTranslated }}
+    {{ range .Translations }}
+        <div><a href="{{ .Permalink }}">{{ i18n (printf "read_%s" .Lang) }}: {{ .Title }}</a></div>
+    {{ end }}
 {{ end }}

--- a/layouts/partials/post/i18nlist.html
+++ b/layouts/partials/post/i18nlist.html
@@ -1,0 +1,3 @@
+{{ range .Translations }}
+    <div><a href="{{ .Permalink }}">{{ i18n (printf "read_%s" .Lang) }}: {{ .Title }}</a></div>
+{{ end }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -6,6 +6,9 @@
       <h1 class="post-title">{{ .Title }}</h1>
 
       <div class="post-meta">
+        <div class="post-meta">
+          {{ partial "post/i18nlist.html" . }}
+        </div>
         <span class="post-time"> {{ .Date.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }} </span>
         {{ with .Params.categories -}}
           <div class="post-category">

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -2,6 +2,9 @@
   <header class="post-header">
     <h1 class="post-title"><a class="post-link" href="{{ .URL }}">{{ .Title }}</a></h1>
     <div class="post-meta">
+      {{ partial "post/i18nlist.html" . }}
+    </div>
+    <div class="post-meta">
       <span class="post-time"> {{ .Date.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }} </span>
       {{ with .Params.categories -}}
         <div class="post-category">


### PR DESCRIPTION
Hi!

I have an idea to show list of available translations somewhere. Currently I placed the list right under post title. It displays if there is at least one translation for the post. In example below I created post in three languages: English, Spanish and Russian.

For English version:
<img width="901" alt="screen shot 2018-04-03 at 23 51 23" src="https://user-images.githubusercontent.com/1475583/38277848-2926ea5a-379a-11e8-977a-65bd9613cd95.png">

For Russian version:
<img width="905" alt="screen shot 2018-04-03 at 23 52 39" src="https://user-images.githubusercontent.com/1475583/38277851-2c82afe0-379a-11e8-9004-3c9ae107d309.png">

What do you think?