### PR TITLE
Undefined .Site.Author.name fix and trailing spaces removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Copy the `config.toml` in the root directory of your website. Overwrite the exis
 # Common-Defined
 title: "An Example Post"
 date: 2018-01-01T16:01:23+08:00
-lastmod: 2018-01-02T16:01:23+08:00 
+lastmod: 2018-01-02T16:01:23+08:00
 draft: false
 tags: ["tag-1", "tag-2", "tag-3"]
 categories: ["index"]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -140,7 +140,7 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
 # [outputs]
 #   home = ["html", "jsonfeed"]
 #   page = ["html"]
-# 
+#
 # [outputFormats]
 # [outputFormats.jsonfeed]
 #   mediaType = "application/json"

--- a/exampleSite/content/post/english-preview.md
+++ b/exampleSite/content/post/english-preview.md
@@ -158,13 +158,13 @@ INFO: 2014/09/29 Using config file: config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [index.html _default/list.html _default/single.html]
 WARN: 2014/09/29 Unable to locate layout: [404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
-$ 
+$
 ```
 
 The "`--verbose`" flag gives extra information that will be helpful when we build the template. Every line of the output that starts with "INFO:" or "WARN:" is present because we used that flag. The lines that start with "WARN:" are warning messages. We'll go over them later.
@@ -190,7 +190,7 @@ $ ls -l public
 total 16
 -rw-r--r--  1 quoha  staff  416 Sep 29 17:02 index.xml
 -rw-r--r--  1 quoha  staff  262 Sep 29 17:02 sitemap.xml
-$ 
+$
 ```
 
 Hugo created two XML files, which is standard, but there are no HTML files.
@@ -207,9 +207,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [index.html _default/list.html _default/single.html]
 WARN: 2014/09/29 Unable to locate layout: [404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -277,7 +277,7 @@ $ find themes -type f | xargs ls -l
 -rw-r--r--  1 quoha  staff     0 Sep 29 17:31 themes/zafta/layouts/partials/footer.html
 -rw-r--r--  1 quoha  staff     0 Sep 29 17:31 themes/zafta/layouts/partials/header.html
 -rw-r--r--  1 quoha  staff    93 Sep 29 17:31 themes/zafta/theme.toml
-$ 
+$
 ```
 
 The skeleton includes templates (the files ending in .html), license file, a description of your theme (the theme.toml file), and an empty archetype.
@@ -340,9 +340,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -387,7 +387,7 @@ When Hugo created our theme, it created an empty home page template. Now, when w
 $ find . -name index.html | xargs ls -l
 -rw-r--r--  1 quoha  staff  0 Sep 29 20:21 ./public/index.html
 -rw-r--r--  1 quoha  staff  0 Sep 29 17:31 ./themes/zafta/layouts/index.html
-$ 
+$
 ```
 
 #### The Magic of Static
@@ -406,7 +406,7 @@ drwxr-xr-x  4 quoha  staff  136 Sep 29 17:31 themes/zafta/layouts/partials
 drwxr-xr-x  4 quoha  staff  136 Sep 29 17:31 themes/zafta/static
 drwxr-xr-x  2 quoha  staff   68 Sep 29 17:31 themes/zafta/static/css
 drwxr-xr-x  2 quoha  staff   68 Sep 29 17:31 themes/zafta/static/js
-$ 
+$
 ```
 
 ## The Theme Development Cycle
@@ -462,9 +462,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -476,9 +476,9 @@ INFO: 2014/09/29 File System Event: ["/Users/quoha/Sites/zafta/themes/zafta/layo
 Change detected, rebuilding site
 
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 1 ms
@@ -500,12 +500,12 @@ Right now, that page is empty because we don't have any content and we don't hav
 
 ```
 $ vi themes/zafta/layouts/index.html
-<!DOCTYPE html> 
-<html> 
-<body> 
-  <p>hugo says hello!</p> 
-</body> 
-</html> 
+<!DOCTYPE html>
+<html>
+<body>
+  <p>hugo says hello!</p>
+</body>
+</html>
 :wq
 
 $
@@ -519,9 +519,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -529,11 +529,11 @@ in 2 ms
 $ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff  78 Sep 29 21:26 public/index.html
 
-$ cat public/index.html 
-<!DOCTYPE html> 
-<html> 
-<body> 
-  <p>hugo says hello!</p> 
+$ cat public/index.html
+<!DOCTYPE html>
+<html>
+<body>
+  <p>hugo says hello!</p>
 </html>
 ```
 
@@ -542,15 +542,15 @@ $ cat public/index.html
 Note: If you're running the server with the `--watch` option, you'll see different content in the file:
 
 ```
-$ cat public/index.html 
-<!DOCTYPE html> 
-<html> 
-<body> 
-  <p>hugo says hello!</p> 
-<script>document.write('<script src="http://' 
-        + (location.host || 'localhost').split(':')[0] 
-    + ':1313/livereload.js?mindelay=10"></' 
-        + 'script>')</script></body> 
+$ cat public/index.html
+<!DOCTYPE html>
+<html>
+<body>
+  <p>hugo says hello!</p>
+<script>document.write('<script src="http://'
+        + (location.host || 'localhost').split(':')[0]
+    + ':1313/livereload.js?mindelay=10"></'
+        + 'script>')</script></body>
 </html>
 ```
 
@@ -573,7 +573,7 @@ INFO: 2014/09/29 attempting to create  post/first.md of post
 INFO: 2014/09/29 curpath: /Users/quoha/Sites/zafta/themes/zafta/archetypes/default.md
 ERROR: 2014/09/29 Unable to Cast <nil> to map[string]interface{}
 
-$ 
+$
 ```
 
 That wasn't very nice, was it?
@@ -612,7 +612,7 @@ total 16
 -rw-r--r--  1 quoha  staff  104 Sep 29 21:54 first.md
 -rw-r--r--  1 quoha  staff  105 Sep 29 21:57 second.md
 
-$ cat content/post/first.md 
+$ cat content/post/first.md
 +++
 Categories = []
 Description = ""
@@ -623,7 +623,7 @@ title = "first"
 +++
 my first post
 
-$ cat content/post/second.md 
+$ cat content/post/second.md
 +++
 Categories = []
 Description = ""
@@ -634,7 +634,7 @@ title = "second"
 +++
 my second post
 
-$ 
+$
 ```
 
 Build the web site and then verify the results.
@@ -647,9 +647,9 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"category":"categories", "tag":"tags"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
@@ -682,7 +682,7 @@ There are three other types of templates: partials, content views, and terms. We
 The home page will contain a list of posts. Let's update its template to add the posts that we just created. The logic in the template will run every time we build the site.
 
 ```
-$ vi themes/zafta/layouts/index.html 
+$ vi themes/zafta/layouts/index.html
 <!DOCTYPE html>
 <html>
 <body>
@@ -720,26 +720,26 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"tag":"tags", "category":"categories"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
-$ find public -type f -name '*.html' | xargs ls -l 
+$ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff  94 Sep 29 22:23 public/index.html
 -rw-r--r--  1 quoha  staff   0 Sep 29 22:23 public/post/first/index.html
 -rw-r--r--  1 quoha  staff   0 Sep 29 22:23 public/post/index.html
 -rw-r--r--  1 quoha  staff   0 Sep 29 22:23 public/post/second/index.html
-$ cat public/index.html 
+$ cat public/index.html
 <!DOCTYPE html>
 <html>
 <body>
-  
+ 
     <h1>second</h1>
-  
+ 
     <h1>first</h1>
-  
+ 
 </body>
 </html>
 $
@@ -771,7 +771,7 @@ Please see the Hugo documentation on template rendering for all the details on d
 #### Update the Template File
 
 ```
-$ vi themes/zafta/layouts/_default/single.html 
+$ vi themes/zafta/layouts/_default/single.html
 <!DOCTYPE html>
 <html>
 <head>
@@ -797,9 +797,9 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"tag":"tags", "category":"categories"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
@@ -810,7 +810,7 @@ $ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff    0 Sep 29 22:40 public/post/index.html
 -rw-r--r--  1 quoha  staff  128 Sep 29 22:40 public/post/second/index.html
 
-$ cat public/post/first/index.html 
+$ cat public/post/first/index.html
 <!DOCTYPE html>
 <html>
 <head>
@@ -823,7 +823,7 @@ $ cat public/post/first/index.html
 </body>
 </html>
 
-$ cat public/post/second/index.html 
+$ cat public/post/second/index.html
 <!DOCTYPE html>
 <html>
 <head>
@@ -866,9 +866,9 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"tag":"tags", "category":"categories"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
@@ -879,15 +879,15 @@ $ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff    0 Sep 29 22:44 public/post/index.html
 -rw-r--r--  1 quoha  staff  128 Sep 29 22:44 public/post/second/index.html
 
-$ cat public/index.html 
+$ cat public/index.html
 <!DOCTYPE html>
 <html>
 <body>
-  
+ 
     <h1><a href="/post/second/">second</a></h1>
-  
+ 
     <h1><a href="/post/first/">first</a></h1>
-  
+ 
 </body>
 </html>
 
@@ -914,7 +914,7 @@ Let's add an "about" page and display it at the top level (as opposed to a sub-l
 The default in Hugo is to use the directory structure of the content/ directory to guide the location of the generated html in the public/ directory. Let's verify that by creating an "about" page at the top level:
 
 ```
-$ vi content/about.md 
+$ vi content/about.md
 +++
 title = "about"
 description = "about this site"

--- a/exampleSite/content/post/jane-theme-preview.md
+++ b/exampleSite/content/post/jane-theme-preview.md
@@ -18,7 +18,7 @@ contentCopyright: '<a href="https://github.com/gohugoio/hugoBasicExample" rel="n
 mathjax: true
 ---
 
-**Markdown** is created by [Daring Fireball](http://daringfireball.net/), the original guideline is [here](http://daringfireball.net/projects/markdown/syntax). Its syntax, however, varies between different parsers or editors. 
+**Markdown** is created by [Daring Fireball](http://daringfireball.net/), the original guideline is [here](http://daringfireball.net/projects/markdown/syntax). Its syntax, however, varies between different parsers or editors.
 
 Please note that HTML fragments in markdown source will be recognized but not parsed or rendered. Also, there may be small reformatting on the original markdown source code after saving.
 
@@ -58,11 +58,11 @@ Markdown uses email-style > characters for block quoting. They are presented as:
 > This is another blockquote with one paragraph. There is three empty line to seperate two blockquote.
 
 
-In typora, just input ‘>’ followed by quote contents a block quote is  generated. Typora will insert proper ‘>’ or line break for you. Block quote inside anther block quote is allowed by adding additional levels of ‘>’. 
+In typora, just input ‘>’ followed by quote contents a block quote is  generated. Typora will insert proper ‘>’ or line break for you. Block quote inside anther block quote is allowed by adding additional levels of ‘>’.
 
 ## Lists
 
-Input `* list item 1` will create an un-ordered list, the `*` symbol can be replace with `+` or `-`. 
+Input `* list item 1` will create an un-ordered list, the `*` symbol can be replace with `+` or `-`.
 
 Input `1. list item 1` will create an ordered list, their markdown source code is like:
 
@@ -109,7 +109,7 @@ You can render *LaTeX* mathematical expressions using **MathJax**.
 
 Input `$$`, then press 'Return' key will trigger an input field which accept *Tex/LaTex* source. Following is an example:
 $$
-\mathbf{V}_1 \times \mathbf{V}_2 =  \begin{vmatrix} 
+\mathbf{V}_1 \times \mathbf{V}_2 =  \begin{vmatrix}
 \mathbf{i} & \mathbf{j} & \mathbf{k} \\
 \frac{\partial X}{\partial u} &  \frac{\partial Y}{\partial u} & 0 \\
 \frac{\partial X}{\partial v} &  \frac{\partial Y}{\partial v} & 0 \\
@@ -121,7 +121,7 @@ In markdown source file, math block is *LaTeX* expression wrapped by ‘$$’ ma
 
 ``` markdown
 $$
-\mathbf{V}_1 \times \mathbf{V}_2 =  \begin{vmatrix} 
+\mathbf{V}_1 \times \mathbf{V}_2 =  \begin{vmatrix}
 \mathbf{i} & \mathbf{j} & \mathbf{k} \\
 \frac{\partial X}{\partial u} &  \frac{\partial Y}{\partial u} & 0 \\
 \frac{\partial X}{\partial v} &  \frac{\partial Y}{\partial v} & 0 \\
@@ -200,7 +200,7 @@ This is [an example](http://example.com/"Title") inline link. (`<p>This is <a hr
 
 Command(on Windows: Ctrl) + Click [This link](#block-elements) will jump to header `Block Elements`. To see how to write that, please move cursor or click that link with `⌘` key pressed to expand the element into markdown source.
 
-### Reference Links 
+### Reference Links
 
 Reference-style links use a second set of square brackets, inside which you place a label of your choosing to identify the link:
 
@@ -261,7 +261,7 @@ Markdown treats asterisks (`*`) and underscores (`_`) as indicators of emphasis.
 _single underscores_
 ```
 
-output: 
+output:
 
 *single asterisks*
 
@@ -325,14 +325,14 @@ Underline is powered by raw HTML.
 
 ## Emoji :happy:
 
-Input emoji with syntax `:smile:`. 
+Input emoji with syntax `:smile:`.
 
-User can trigger auto-complete suggestions for emoji by pressing `ESC` key, or trigger it automatically after enable it on preference panel. Also, input UTF8 emoji char directly from `Edit` -> `Emoji & Symbols` from menu bar is also supported. 
+User can trigger auto-complete suggestions for emoji by pressing `ESC` key, or trigger it automatically after enable it on preference panel. Also, input UTF8 emoji char directly from `Edit` -> `Emoji & Symbols` from menu bar is also supported.
 
 
 ## Inline Math
 
-To use this feature, first, please enable it in `Preference` Panel -> `Markdown` Tab. Then use `$` to wrap TeX command, for example: `$\lim_{x \to \infty} \exp(-x) = 0$` will be rendered as LaTeX command. 
+To use this feature, first, please enable it in `Preference` Panel -> `Markdown` Tab. Then use `$` to wrap TeX command, for example: `$\lim_{x \to \infty} \exp(-x) = 0$` will be rendered as LaTeX command.
 
 To trigger inline preview for inline math: input “$”, then press `ESC` key, then input TeX command, a preview tooltip will be visible like below:
 

--- a/exampleSite/content/post/shortcodes-preview.md
+++ b/exampleSite/content/post/shortcodes-preview.md
@@ -18,7 +18,7 @@ A shortcode is a simple snippet inside a content file that Hugo will render usin
 
 In addition to cleaner Markdown, shortcodes can be updated any time to reflect new classes, techniques, or standards. At the point of site generation, Hugo shortcodes will easily merge in your changes. You avoid a possibly complicated search and replace operation.
 
-More details: https://gohugo.io/content-management/shortcodes/ 
+More details: https://gohugo.io/content-management/shortcodes/
 
 <!--more-->
 

--- a/exampleSite/content/post/syntax-highlighting.md
+++ b/exampleSite/content/post/syntax-highlighting.md
@@ -52,10 +52,10 @@ int main(void){
 ```
 
 ```cpp
-// 'Hello World!' program 
- 
+// 'Hello World!' program
+
 #include <iostream>
- 
+
 int main(){
   std::cout << "Hello World!" << std::endl;
   return 0;
@@ -65,7 +65,7 @@ int main(){
 ```cs
 using System;
 class HelloWorld{
-  public static void Main(){ 
+  public static void Main(){
     System.Console.WriteLine("Hello, World!");
   }
 }
@@ -83,7 +83,7 @@ class HelloWorld{
 package main
 import fmt "fmt"
 
-func main() 
+func main()
 {
    fmt.Printf("Hello, World!\n");
 }
@@ -102,5 +102,5 @@ object HelloWorld with Application {
 ```
 
 ```python
-print("Hello, World!") 
+print("Hello, World!")
 ```

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,7 @@
     <h1 class="post-title">{{ .Title }}</h1>
     {{ partial "post/i18nlist.html" . }}
     <div class="post-meta">
-      <span class="post-time"> 
+      <span class="post-time">
         {{ .Date.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }}
       </span>
     </div>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -60,7 +60,7 @@
           {{ $count := len $taxonomy.Pages }}
           {{ $weigth := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
           {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weigth) ) }}
-          <!--Current font size: {{$currentFontSize}}-->   
+          <!--Current font size: {{$currentFontSize}}-->  
           <a href="/tags/{{ $name | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}" style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{ $name }}</a>
         {{ end }}
         </div>

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -26,14 +26,14 @@
 
   <!-- changyan -->
   {{- if and .Site.Params.changyanAppid .Site.Params.changyanAppkey -}}
-    <div id="SOHUCS"></div> 
-    <script type="text/javascript"> 
+    <div id="SOHUCS"></div>
+    <script type="text/javascript">
     (function(){
       if (window.location.hostname === 'localhost') return;
 
       var appid = '{{ .Site.Params.changyanAppid }}';
       var conf = '{{ .Site.Params.changyanAppkey }}';
-      var width = window.innerWidth || document.documentElement.clientWidth; 
+      var width = window.innerWidth || document.documentElement.clientWidth;
       if (width < 960) {window.document.write('<script id="changyan_mobile_js" charset="utf-8" type="text/javascript" src="https://changyan.sohu.com/upload/mobile/wap-js/changyan_mobile.js?client_id=' + appid + '&conf=' + conf + '"><\/script>'); } else { var loadJs=function(d,a){var c=document.getElementsByTagName("head")[0]||document.head||document.documentElement;var b=document.createElement("script");b.setAttribute("type","text/javascript");b.setAttribute("charset","UTF-8");b.setAttribute("src",d);if(typeof a==="function"){if(window.attachEvent){b.onreadystatechange=function(){var e=b.readyState;if(e==="loaded"||e==="complete"){b.onreadystatechange=null;a()}}}else{b.onload=a}}c.appendChild(b)};loadJs("https://changyan.sohu.com/upload/changyan.js",function(){window.changyan.api.config({appid:appid,conf:conf})}); }
     })();
     </script>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,12 +2,12 @@
   {{- range $name, $path := .Site.Params.social }}
     {{- if $path }}
       {{- $realName := slicestr $name 2 }}
-      <a href="{{ $path | safeURL }}" rel="me" class="iconfont icon-{{ $realName }}" 
+      <a href="{{ $path | safeURL }}" rel="me" class="iconfont icon-{{ $realName }}"
         title="{{ $realName }}" target="_blank">
       </a>
     {{- end }}
   {{- end }}
-  <a href="{{ .Site.RSSLink }}" type="application/rss+xml" class="iconfont icon-rss" 
+  <a href="{{ .Site.RSSLink }}" type="application/rss+xml" class="iconfont icon-rss"
     title="rss" target="_blank">
   </a>
 </div>
@@ -23,14 +23,16 @@
 
   <span class="copyright-year">
     {{- $current := now.Format "2006" }}
-    &copy; 
+    &copy;
     {{ if ne .Site.Params.since $current }}
-      {{ .Site.Params.since }} - 
+      {{ .Site.Params.since }} -
     {{ end }}
     {{- $current }}
     <span class="heart">
       <i class="iconfont icon-heart"></i>
     </span>
+{{- if or .Site.Copyright .Site.Author.name -}}
     <span class="author">{{if .Site.Copyright }}{{ .Site.Copyright | safeHTML }}{{ else }}{{ .Site.Author.name | safeHTML }}{{ end }}</span>
+{{- end -}}
   </span>
 </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,7 +23,9 @@
 <meta name="mobile-web-app-capable" content="yes">
 
 <!-- author & description & keywords  -->
+{{- if or .Params.author .Site.Author.name -}}
 <meta name="author" content="{{ if .Params.author }}{{ .Params.author | safeHTML }}{{ else }}{{ .Site.Author.name | safeHTML }}{{ end }}" />
+{{- end -}}
 
 {{- if .Description -}}
   <meta name="description" content="{{ .Description | safeHTML }}" />

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -49,7 +49,7 @@
   {{ else if gt $pag.TotalPages $max_links }}
 
     <nav class="pagination">
-      
+     
       <!-- First page. -->
       {{ if ne $pag.PageNumber 1 }}
       <li><a href="{{ $pag.First.URL }}">««</a></li>
@@ -59,10 +59,10 @@
       {{ if $pag.HasPrev }}
       <li><a href="{{ $pag.Prev.URL }}">«</a></li>
       {{ end }}
-    
+   
       <!-- Page numbers. -->
       {{ range $pag.Pagers }}
-      
+     
         {{ $.Scratch.Set "page_number_flag" false }}
 
         <!-- Advanced page numbers. -->
@@ -88,7 +88,7 @@
 
           <!-- Middle pages. -->
           {{ else }}
-            
+           
             {{ if and ( ge .PageNumber (sub $pag.PageNumber $adjacent_links) ) ( le .PageNumber (add $pag.PageNumber $adjacent_links) ) }}
               {{ $.Scratch.Set "page_number_flag" true }}
             {{ end }}

--- a/layouts/shortcodes/music.html
+++ b/layouts/shortcodes/music.html
@@ -1,39 +1,39 @@
   {{/*
       ## Music 163
-  
+ 
       ### Params:
-  
+ 
       - `id`
-  
+ 
         required param
         you can extract from music url
         url format "http://music.163.com/#/song?id=3950552"
-  
+ 
       - Fiddle `auto`
-  
+ 
         optional param
         default value 0
         you can overwrite it with 1
-  
+ 
       ### Examples:
-  
+ 
       - Simple
-  
+ 
         {{% music "3950552" %}}
         {{% music "3950552" "1" %}}
-  
+ 
       - Named Params
-  
+ 
         {{% music id="3950552" %}}
         {{% music id="3950552" auto="1" %}}
-  
+ 
   */}}
-  
+ 
   {{- /* DEFAULTS */ -}}
   {{ $auto := "0" }}
-  
+ 
   {{- if .IsNamedParams -}}
-  
+ 
     <iframe style="max-width: 100%"
       class="music163"
       frameborder="no"
@@ -44,9 +44,9 @@
       height="86"
       src="//music.163.com/outchain/player?type=2&id={{ .Get "id" }}&auto={{ or (.Get "auto") $auto }}&height=66">
     </iframe>
-  
+ 
   {{- else -}}
-  
+ 
     <iframe style="max-width: 100%"
       class="music163"
       frameborder="no"
@@ -57,6 +57,6 @@
       height="86"
       src="//music.163.com/outchain/player?type=2&id={{ .Get 0 }}&auto={{ if isset .Params 1 }}{{ .Get 1 }}{{ else }}{{ $auto }}{{ end }}&height=66">
     </iframe>
-  
+ 
   {{- end -}}
-  
+ 

--- a/layouts/shortcodes/youku.html
+++ b/layouts/shortcodes/youku.html
@@ -1,12 +1,12 @@
 {{ if .IsNamedParams }}
 <div {{ if .Get "class" }}class="{{ .Get "class" }}"{{ else }}style="position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; overflow: hidden;"{{ end }}>
-  <iframe src="//www.youku.com/embed/{{ .Get " id " }}?{{ with .Get "autoplay" }}{{ if eq . "true " }}autoplay=1{{ end }}{{ end }}" 
+  <iframe src="//www.youku.com/embed/{{ .Get " id " }}?{{ with .Get "autoplay" }}{{ if eq . "true " }}autoplay=1{{ end }}{{ end }}"
   {{ if not (.Get "class") }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"{{ end }}
   allowfullscreen frameborder="0" title="YouKu Video"></iframe>
 </div>
 {{ else }}
 <div {{ if len .Params | eq 2 }}class="{{ .Get 1 }}" {{ else }}style="position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; overflow: hidden;"{{ end }}>
-  <iframe src="//player.youku.com/embed/{{ .Get 0 }}?autoplay=0" 
+  <iframe src="//player.youku.com/embed/{{ .Get 0 }}?autoplay=0"
   {{ if len .Params | eq 1 }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"{{ end }}
   allowfullscreen frameborder="0" title="YouKu Video"></iframe>
 </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
                   new IconfontWebpackPlugin({
                     resolve: loader.resolve,
                     fontNamePrefix: 'custom-',
-                    modules: false, 
+                    modules: false,
                   })
                 ]
                }


### PR DESCRIPTION
Hello!

This path removes trailing spaces (my editor removed them from files I've edited and I've applied the change to everything to prevent this from happening to someone else) and fixes render errors in case of undefined `.Site.Author.name` for `head` and `footer` partials - without this path they won't render at all, after it just problem lines won't be added.