### PR TITLE
change safeURL to absLangURL in site-navbar menu for multi languages

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,11 +14,11 @@
       <li class="menu-item">
         {{ if .HasChildren }}
           <!-- drop down navigation MENU -->
-          <a class="menu-item-link menu-parent" href="{{ .URL | safeURL }}">{{ .Name }}</a>
+          <a class="menu-item-link menu-parent" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
           <ul class="submenu">
             {{ range .Children }}
               <li>
-                <a href="{{ .URL | safeURL }}">{{ .Name }}</a>
+                <a href="{{ .URL | absLangURL }}">{{ .Name }}</a>
               </li>
             {{ end }}
           </ul>
@@ -26,12 +26,12 @@
         {{ else }}
           <!-- normal MENU -->
           {{ if hasPrefix .URL "http" }}
-            <a class="menu-item-link" href="{{ .URL | safeURL }}" rel="noopener" target="_blank">
+            <a class="menu-item-link" href="{{ .URL | absLangURL }}" rel="noopener" target="_blank">
               {{ .Name }}
             <i class="iconfont icon-new-window"></i>
             </a>
           {{ else }}
-            <a class="menu-item-link" href="{{ .URL | safeURL }}">{{ .Name }}</a>
+            <a class="menu-item-link" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
           {{ end }}
 
         {{ end  }}


### PR DESCRIPTION
After multi-language setting is enabled, once I change to another language, and click the site navbar menu, the site url may redirects to the default language menu.

The absolute URL function you use in the file `layouts/partials/header.html` is [safeURL](https://gohugo.io/functions/safeurl/). Changing it to function [absLangURL](https://gohugo.io/functions/abslangurl/) will solve the issue.

You can see the effect on my [blog](https://axdlog.com).