### PR TITLE
use relLangURL for multilingual support

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -4,7 +4,7 @@
 <div class="not-found">
   <h1 class="error-emoji"></h1>
   <p class="error-text">/* 404 page not found. */</p>
-  <p class="error-link"><a href="{{ "/" | relURL }}">↑ Back Home ↑</a></p>
+  <p class="error-link"><a href="{{ "/" | relLangURL }}">↑ Back Home ↑</a></p>
 </div>
 <script>
   var errorEmojiContainer = document.getElementsByClassName('error-emoji')[0];

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -13,7 +13,7 @@
         </div>
           <div class="collection-title">
             <h2 class="archive-year">
-              <a href="{{ $termName | urlize | relURL }}/{{ $value.Term | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}">
+              <a href="{{ $termName | urlize | relLangURL }}/{{ $value.Term | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}">
                 {{ i18n "category" }}{{ $value.Term }}
               </a>
             </h2>
@@ -33,7 +33,7 @@
           {{ end }}
           {{ if gt (len $value.Pages) 5 }}
             <div class="more-post">
-              <a href="{{ $termName | urlize | relURL }}/{{ $value.Term | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}" class="more-post-link">{{ i18n "morePost" }}</a>
+              <a href="{{ $termName | urlize | relLangURL }}/{{ $value.Term | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}" class="more-post-link">{{ i18n "morePost" }}</a>
             </div>
           {{ end }}
       </section>
@@ -62,7 +62,7 @@
         {{ $weigth := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
         {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weigth) ) }}
         <!--Current font size: {{$currentFontSize}}-->  
-        <a href="{{ $termName | urlize | relURL }}/{{ $tagName | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}" 
+        <a href="{{ $termName | urlize | relLangURL }}/{{ $tagName | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}" 
           style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{ $tagName }}</a>
       {{ end }}
       </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <div class="logo-wrapper">
-  <a href="{{ "/" | relURL }}" class="logo">
+  <a href="{{ "/" | relLangURL }}" class="logo">
     {{ if .Site.Params.logoTitle }}
       {{ .Site.Params.logoTitle | safeHTML }}
     {{ else }}

--- a/layouts/partials/slideout.html
+++ b/layouts/partials/slideout.html
@@ -1,6 +1,6 @@
 <div id="mobile-navbar" class="mobile-navbar">
   <div class="mobile-header-logo">
-    <a href="{{ "/" | relURL }}" class="logo">
+    <a href="{{ "/" | relLangURL }}" class="logo">
       {{- if .Site.Params.logoTitle -}}
         {{ .Site.Params.logoTitle }}
       {{- else -}}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -10,7 +10,7 @@
         {{ with .Params.categories -}}
           <div class="post-category">
             {{ range . }}
-              <a href="{{ "categories" | relURL }}/{{ . | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}"> {{ . }} </a>
+              <a href="{{ "categories" | relLangURL }}/{{ . | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}"> {{ . }} </a>
             {{ end }}
           </div>
         {{- end }}
@@ -39,7 +39,7 @@
       {{ with .Params.tags -}}
         <div class="post-tags">
           {{ range . }}
-          <a href="{{ "tags" | relURL }}/{{ . | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}">{{ . }}</a>
+          <a href="{{ "tags" | relLangURL }}/{{ . | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}">{{ . }}</a>
           {{ end }}
         </div>
       {{- end }}

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -7,7 +7,7 @@
       {{ with .Params.categories -}}
         <div class="post-category">
           {{ range . }}
-            <a href="{{ "categories" | relURL }}/{{ . | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}"> {{ . }} </a>
+            <a href="{{ "categories" | relLangURL }}/{{ . | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}"> {{ . }} </a>
           {{ end }}
         </div>
       {{- end }}


### PR DESCRIPTION
Many links are broken in subsites of different languages. This fix that.
I also change `{{ "/" | relURL }}` to `{{ "/" | relLangURL }}` because it seems strange to redirect to default language when you click those links in a subsite of different language.