### PR TITLE
link to correct RSS URL, fix #75

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,9 +7,13 @@
       </a>
     {{- end }}
   {{- end }}
-  <a href="{{ .Site.RSSLink }}" rel="noopener" type="application/rss+xml" class="iconfont icon-rss"
+  {{ with .Site.GetPage "home" -}}
+  {{- with .OutputFormats.Get "RSS" -}}
+  <a href="{{ .Permalink }}" rel="noopener {{ .Rel }}" type="{{ .MediaType.Type }}" class="iconfont icon-rss"
     title="rss" target="_blank">
   </a>
+  {{ end -}}
+  {{- end -}}
 </div>
 
 <div class="copyright">


### PR DESCRIPTION
As talked about in #75, current RSS link in multilingual environment is incorrect.
BTW, as I am new to Hugo development, I am not sure whether there is a better syntax than the two `with`s.