### PR TITLE
remove hardcoded URLs for tags/categories

### DIFF
--- a/dev-config.toml
+++ b/dev-config.toml
@@ -108,7 +108,6 @@ defaultContentLanguage = "en"  # Default language to use (if you setup multiling
 
 [params]
   debug = false             # If true, load `eruda.min.js`. See https://github.com/liriliri/eruda
-  # uglyURLs = true          # You must set true after use uglyURLs in site (above). because $.Site.UglyURLs can not import.
   since = "2017"            # Site creation time          # 站点建立时间
   homeFullContent = false   # if false, show post summaries on home page. Othewise show full content.
   rssFullContent = true     # if false, Rss feed instead of the summary

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -59,7 +59,6 @@ defaultContentLanguage = "en"           # Default language to use
 
 [params]
   debug = false             # If true, load `eruda.min.js`. See https://github.com/liriliri/eruda
-  # uglyURLs = true          # You must set true after use uglyURLs in site (above). because $.Site.UglyURLs can not import.
   since = "2017"            # Site creation time          # 站点建立时间
   homeFullContent = false   # if false, show post summaries on home page. Othewise show full content.
   rssFullContent = true     # if false, Rss feed instead of the summary

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -4,22 +4,26 @@
   {{ $termName := .Data.Plural }}
   {{ $terms := .Data.Terms.ByCount }}
   {{ $length := len $terms }}
+  {{ $type := .Type }}
 
   <!-- Categories Page -->
   {{ if and $.Site.Taxonomies.categories (eq $termName "categories") }}
-    {{ range $key, $value := $terms }}
+    {{ range $terms }}
+    {{ $term := .Term }}
+    {{ $pages := .Pages }}
+    {{ with $.Site.GetPage "taxonomy" $type $term }}
       <section id="archive" class="archive">
         <div class="archive-title">
         </div>
           <div class="collection-title">
             <h2 class="archive-year">
-              <a href="{{ $termName | urlize | relLangURL }}/{{ $value.Term | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}">
-                {{ i18n "category" }}{{ $value.Term }}
+              <a href="{{ .Permalink }}">
+                {{ i18n "category" }}{{ $term }}
               </a>
             </h2>
           </div>
 
-          {{ range first 5 $value.Pages }}
+          {{ range first 5 $pages }}
             <div class="archive-post">
               <span class="archive-post-time">
                 {{ .Date.Format "2006-01-02" }}
@@ -31,12 +35,13 @@
               </span>
             </div>
           {{ end }}
-          {{ if gt (len $value.Pages) 5 }}
+          {{ if gt (len $pages) 5 }}
             <div class="more-post">
-              <a href="{{ $termName | urlize | relLangURL }}/{{ $value.Term | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}" class="more-post-link">{{ i18n "morePost" }}</a>
+              <a href="{{ .Permalink }}" class="more-post-link">{{ i18n "morePost" }}</a>
             </div>
           {{ end }}
       </section>
+    {{ end }}
     {{ end }}
 
   <!-- Tag cloud Page -->
@@ -61,9 +66,11 @@
         {{ $count := len $taxonomy.Pages }}
         {{ $weigth := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
         {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weigth) ) }}
+        {{ with $.Site.GetPage "taxonomy" $type $tagName }}
         <!--Current font size: {{$currentFontSize}}-->  
-        <a href="{{ $termName | urlize | relLangURL }}/{{ $tagName | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}" 
+        <a href="{{ .Permalink }}" 
           style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{ $tagName }}</a>
+        {{ end }}
       {{ end }}
       </div>
     </div>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -10,7 +10,10 @@
         {{ with .Params.categories -}}
           <div class="post-category">
             {{ range . }}
-              <a href="{{ "categories" | relLangURL }}/{{ . | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}"> {{ . }} </a>
+            {{- $name := . -}}
+            {{- with $.Site.GetPage "taxonomy" "categories" $name -}}
+              <a href="{{ .Permalink }}"> {{ $name }} </a>
+            {{ end -}}
             {{ end }}
           </div>
         {{- end }}
@@ -39,7 +42,10 @@
       {{ with .Params.tags -}}
         <div class="post-tags">
           {{ range . }}
-          <a href="{{ "tags" | relLangURL }}/{{ . | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}">{{ . }}</a>
+          {{- $name := . -}}
+          {{- with $.Site.GetPage "taxonomy" "tags" $name -}}
+          <a href="{{ .Permalink }}">{{ $name }}</a>
+          {{ end -}}
           {{ end }}
         </div>
       {{- end }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -11,7 +11,7 @@
           <div class="post-category">
             {{ range . }}
             {{- $name := . -}}
-            {{- with $.Site.GetPage "taxonomy" "categories" $name -}}
+            {{- with $.Site.GetPage "taxonomy" "categories" $name | default ($.Site.GetPage "taxonomy" "categories" ($name | urlize)) -}}
               <a href="{{ .Permalink }}"> {{ $name }} </a>
             {{ end -}}
             {{ end }}
@@ -43,7 +43,7 @@
         <div class="post-tags">
           {{ range . }}
           {{- $name := . -}}
-          {{- with $.Site.GetPage "taxonomy" "tags" $name -}}
+          {{- with $.Site.GetPage "taxonomy" "tags" $name | default ($.Site.GetPage "taxonomy" "tags" ($name | urlize)) -}}
           <a href="{{ .Permalink }}">{{ $name }}</a>
           {{ end -}}
           {{ end }}

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -7,7 +7,10 @@
       {{ with .Params.categories -}}
         <div class="post-category">
           {{ range . }}
-            <a href="{{ "categories" | relLangURL }}/{{ . | urlize }}{{if $.Site.Params.uglyURLs}}.html{{else}}/{{end}}"> {{ . }} </a>
+          {{- $name := . -}}
+          {{- with $.Site.GetPage "taxonomy" "categories" $name -}}
+            <a href="{{ .Permalink }}"> {{ $name }} </a>
+          {{ end -}}
           {{ end }}
         </div>
       {{- end }}

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -8,7 +8,7 @@
         <div class="post-category">
           {{ range . }}
           {{- $name := . -}}
-          {{- with $.Site.GetPage "taxonomy" "categories" $name -}}
+          {{- with $.Site.GetPage "taxonomy" "categories" $name | default ($.Site.GetPage "taxonomy" "categories" ($name | urlize)) -}}
             <a href="{{ .Permalink }}"> {{ $name }} </a>
           {{ end -}}
           {{ end }}


### PR DESCRIPTION
See discussions here: https://discourse.gohugo.io/t/how-to-get-permalink-of-taxonomies-in-templates/12927

This PR allows users to modify the permalinks for tags and categories without breaking the links. E.g.,

```
[permalinks]
tags = "/tag/:slug/"
```

In addition, `params.uglyURLs` is no longer needed because now the URLs can be automatically inferred by the system even when `uglyURLs` = `true`.