### PR TITLE
fix: tag include "#" Special character show 404

### DIFF
--- a/exampleSite/content/post/jane-theme-preview.md
+++ b/exampleSite/content/post/jane-theme-preview.md
@@ -3,8 +3,8 @@ title: "Jane Theme Preview"
 date: 2018-03-06T16:01:23+08:00
 lastmod: 2018-03-07T16:01:23+08:00
 draft: false
-tags: ["preview", "shortcodes", "tag-6"]
-categories: ["docs", "shortcodes", "index"]
+tags: ["preview", "shortcodes", "tag-6", "##"]
+categories: ["docs", "shortcodes", "index", "##"]
 author: "Typora"
 
 # You can also close(false) or open(true) something for this content.
@@ -61,7 +61,7 @@ Markdown uses email-style > characters for block quoting. They are presented as:
 > This is another blockquote with one paragraph. There is three empty line to seperate two blockquote.
 >
 > 这是一段中文测试。
-> 
+>
 
 
 In typora, just input ‘>’ followed by quote contents a block quote is  generated. Typora will insert proper ‘>’ or line break for you. Block quote inside anther block quote is allowed by adding additional levels of ‘>’.

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -17,7 +17,7 @@
         </div>
           <div class="collection-title">
             <h2 class="archive-year">
-              <a href="{{ .Permalink }}">
+              <a href="{{ replace .Permalink "#" "%23" }}">
                 {{ i18n "category" }}{{ $term }}
               </a>
             </h2>
@@ -37,7 +37,7 @@
           {{ end }}
           {{ if gt (len $pages) 5 }}
             <div class="more-post">
-              <a href="{{ .Permalink }}" class="more-post-link">{{ i18n "morePost" }}</a>
+              <a href="{{ replace .Permalink "#" "%23" }}" class="more-post-link">{{ i18n "morePost" }}</a>
             </div>
           {{ end }}
       </section>
@@ -67,8 +67,8 @@
         {{ $weigth := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
         {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weigth) ) }}
         {{ with $.Site.GetPage "taxonomy" $type $tagName }}
-        <!--Current font size: {{$currentFontSize}}-->  
-        <a href="{{ .Permalink }}" 
+        <!--Current font size: {{$currentFontSize}}-->
+        <a href="{{ replace .Permalink "#" "%23" }}"
           style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{ $tagName }}</a>
         {{ end }}
       {{ end }}


### PR DESCRIPTION
If I have a tag named `C#`, the url is `http://localhost:1313/tags/c#/` , this url show 404 page.

`#` sign in url is Special characters. Then I change the `#` to `%23`, Then it works.

This PR purpose is to solve this problem. 

I am not sure whether there is a better solution.

And should we fix this bug?