### PR TITLE
fix API incompatibility for v0.45

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -11,7 +11,7 @@
     {{ range $terms }}
     {{ $term := .Term }}
     {{ $pages := .Pages }}
-    {{ with $.Site.GetPage "taxonomy" $type $term }}
+    {{ with $.Site.GetPage "taxonomy" (printf "%s/%s" $type $term) }}
       <section id="archive" class="archive">
         <div class="archive-title">
         </div>
@@ -66,7 +66,7 @@
         {{ $count := len $taxonomy.Pages }}
         {{ $weigth := div (sub (math.Log $count) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
         {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weigth) ) }}
-        {{ with $.Site.GetPage "taxonomy" $type $tagName }}
+        {{ with $.Site.GetPage "taxonomy" (printf "%s/%s" $type $tagName) }}
         <!--Current font size: {{$currentFontSize}}-->  
         <a href="{{ .Permalink }}" 
           style="font-size:{{$currentFontSize}}{{$fontUnit}}">{{ $tagName }}</a>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -11,7 +11,7 @@
           <div class="post-category">
             {{ range . }}
             {{- $name := . -}}
-            {{- with $.Site.GetPage "taxonomy" "categories" $name | default ($.Site.GetPage "taxonomy" "categories" ($name | urlize)) -}}
+            {{- with $.Site.GetPage "taxonomy" (printf "categories/%s" $name) | default ($.Site.GetPage "taxonomy" (printf "categories/%s" ($name | urlize))) -}}
               <a href="{{ .Permalink }}"> {{ $name }} </a>
             {{ end -}}
             {{ end }}
@@ -43,7 +43,7 @@
         <div class="post-tags">
           {{ range . }}
           {{- $name := . -}}
-          {{- with $.Site.GetPage "taxonomy" "tags" $name | default ($.Site.GetPage "taxonomy" "tags" ($name | urlize)) -}}
+          {{- with $.Site.GetPage "taxonomy" (printf "tags/%s" $name) | default ($.Site.GetPage "taxonomy" (printf "tags/%s" ($name | urlize))) -}}
           <a href="{{ .Permalink }}">{{ $name }}</a>
           {{ end -}}
           {{ end }}

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -8,7 +8,7 @@
         <div class="post-category">
           {{ range . }}
           {{- $name := . -}}
-          {{- with $.Site.GetPage "taxonomy" "categories" $name | default ($.Site.GetPage "taxonomy" "categories" ($name | urlize)) -}}
+          {{- with $.Site.GetPage "taxonomy" (printf "categories/%s" $name) | default ($.Site.GetPage "taxonomy" (printf "categories/%s" ($name | urlize))) -}}
             <a href="{{ .Permalink }}"> {{ $name }} </a>
           {{ end -}}
           {{ end }}


### PR DESCRIPTION
Hugo v0.45 no longer supports three-argument form for `GetPage`.
(The two-argument form is supported in previous versions as well.)