### PR TITLE
disable google analytics on localhost

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -96,7 +96,7 @@
 <![endif]-->` | safeHTML }}
 
 <!-- Analytics -->
-{{- if .Site.GoogleAnalytics -}}
+{{- if and (not .Site.IsServer) .Site.GoogleAnalytics -}}
   {{ template "_internal/google_analytics_async.html" . }}
 {{- end -}}
 


### PR DESCRIPTION
This disables google analytics when executing `hugo server`