### PR TITLE
fix `<link hreflang="lang_code"... >`

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,6 @@
-<link rel="alternate" hreflang="{{ $.Site.LanguageCode | default "en" }}" href="{{ $.Site.BaseURL  }}" />
+{{ range .Translations }}
+<link rel="alternate" hreflang="{{ .Site.LanguageCode }}" href="{{ .Permalink  }}" />
+{{ end }}
 
 <meta name="renderer" content="webkit" />
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>


### PR DESCRIPTION
See https://support.google.com/webmasters/answer/189077.
`<link hreflang="lang_code"... >` should point to translated pages.