### PR TITLE
don't split threads when query parameters exist

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -65,6 +65,9 @@
   </div>
   <div id="disqus_thread"></div>
   <script type="text/javascript">
+    var disqus_config = function () {
+      this.page.url = {{ .Permalink }};
+    };
     function load_disqus() {
       // Don't ever inject Disqus on localhost--it creates unwanted
       // discussions from 'localhost:1313' on your Disqus account...


### PR DESCRIPTION
Prevent splitting Disqus threads for
`URL/?test=1`, `URL/?test=2`, `URL/?test=3`, etc...