### PR TITLE
fix busuanzi js url

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -87,7 +87,7 @@
 
 <!-- Counter busuanzi -->
 {{ if .Site.Params.counter.busuanzi.enable }}
-  <script async src="//dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js"></script>
+  <script async src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
 {{ end }}
 
 <!-- Counter leancloud -->


### PR DESCRIPTION
不蒜子 JS 文件地址变了。

> 因七牛强制过期『dn-lbstatics.qbox.me』域名，与客服沟通无果，只能更换域名到『busuanzi.ibruce.info』！