### PR TITLE
add  google_analytics

### DIFF
--- a/dev-config.toml
+++ b/dev-config.toml
@@ -149,6 +149,7 @@ defaultContentLanguage = "en"  # Default language to use (if you setup multiling
   baidu_analytics = ""      # Baidu Analytics
   baidu_verification = ""   # Baidu Verification
   google_verification = ""  # Google_Verification         # 谷歌
+  google_analytics = ""     # Google Analytics            # 谷歌分析
 
   # Link custom CSS and JS assets
   #   (relative to /static/css and /static/js respectively)

--- a/exampleSite/full-config.toml
+++ b/exampleSite/full-config.toml
@@ -108,6 +108,7 @@ defaultContentLanguage = "en"           # Default language to use
   baidu_analytics = ""      # Baidu Analytics
   baidu_verification = ""   # Baidu Verification
   google_verification = ""  # Google_Verification         # 谷歌
+  google_analytics = ""     # Google Analytics            # 谷歌分析
 
   # Link custom CSS and JS assets
   #   (relative to /static/css and /static/js respectively)

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,3 +1,13 @@
+{{ with .Site.Params.google_analytics }}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{.}}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', '{{.}}');
+</script>
+{{ end }}
+
 {{ range .Translations }}
 <link rel="alternate" hreflang="{{ .Site.LanguageCode }}" href="{{ .Permalink  }}" />
 {{ end }}


### PR DESCRIPTION
add google analytics js code, and this configration code 
but some chrome://extensions/ ( ex :uBlock ) will block this request 

https://support.google.com/analytics/answer/1008080
---
添加谷歌分析的代码，以及相关的配置
但是，会有一些扩展的插件，比如chrome 的 uBlock  插件 会阻止，这种类似的跟踪用户行为的访问。