### PR TITLE
add crossorigin="anonymous"

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -77,7 +77,7 @@
 
 <!-- Jane theme main style -->
 {{ $style := resources.Get "sass/jane.scss" | toCSS | minify | fingerprint }}
-<link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" media="screen">
+<link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" media="screen" crossorigin="anonymous">
 <!-- End -->
 
 <!-- custom css -->

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -13,7 +13,7 @@
 <!-- Jane theme main js -->
 {{ $jsTemplate := resources.Get "js/main.js" }}
 {{ $secureJS := $jsTemplate | resources.ExecuteAsTemplate "js/main.js" . | fingerprint }}
-<script type="text/javascript" src="{{ $secureJS.RelPermalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
+<script type="text/javascript" src="{{ $secureJS.RelPermalink }}" integrity="{{ $secureJS.Data.Integrity }}" crossorigin="anonymous"></script>
 <!-- End -->
 
 {{- if and (or .Params.mathjax (and .Site.Params.mathjax (ne .Params.mathjax false))) (or .IsPage .IsHome) }}


### PR DESCRIPTION
Currently, Google web cache could not access the css and js files because of cross origin restriction. (e.g., [this cached page](https://webcache.googleusercontent.com/search?q=cache:e7V0nixAgu4J:https://island.shaform.com/zh/how-to-read-this-blog/+).)

This commit attempts to resolve this issue.