### PR TITLE
allow using Markdown in author description

### DIFF
--- a/layouts/partials/author_info.html
+++ b/layouts/partials/author_info.html
@@ -15,7 +15,7 @@
     <p class="author-title">{{ i18n "author" }}</p>
     <p class="author-name">{{ $author_name }}</p>
     {{ with $author_desc -}}
-    <p class="author-desc">{{ . }}</p>
+    <p class="author-desc">{{ . | markdownify }}</p>
     {{- end }}
     </div>
     <div class="author-bottom"></div>


### PR DESCRIPTION
Previously, author description only supports raw texts. But maybe markdown support is useful.