### PR TITLE
Remove word-break from post "a" tag, add "target" and "rel" params to figure shortcode

### DIFF
--- a/assets/sass/_partial/_post/_content.scss
+++ b/assets/sass/_partial/_post/_content.scss
@@ -30,7 +30,6 @@
 
   a {
     color: $theme-color;
-    word-break: break-all;
 
     &:hover {
       border-bottom: $content-link-border;

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -15,7 +15,7 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
     <div class="img"{{ if .Parent }} style="background-image: url('{{ print $thumb }}');"{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>
       <img itemprop="thumbnail" src="{{ $thumb }}" {{ with .Get "alt" | default (.Get "caption") }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
     </div>
-    {{ with .Get "link" | default (.Get "src") }}<a href="{{.}}" itemprop="contentUrl"></a>{{ end }}
+    {{ with .Get "link" | default (.Get "src") }}<a href="{{.}}"{{ with $.Get "target" }} target="{{.}}"{{ end }}{{ with $.Get "rel" }} rel="{{.}}"{{ end }} itemprop="contentUrl"></a>{{ end }}
     {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
       <figcaption>
         {{- with .Get "title" }}<h4>{{.}}</h4>{{ end }}


### PR DESCRIPTION
First commit remove word-break from post `a` tag, fixing #225. However, I didn't regenerated scss resources as I don't know how to do that properly: Readme have no instructions on that, we should fix it.
Second commit add `target` and `rel` params to figure shortcode, helping (or fixing) #223.