### PR TITLE
fix #222: pagination links

### DIFF
--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -5,7 +5,7 @@
 <nav class="pagination">
 
   {{ with $pag.Prev }}
-  <a class="prev" href="{{ .RelPermalink }}">
+  <a class="prev" href="{{ .URL }}">
     <i class="iconfont">
       {{ partial "svg/left.svg" }}
     </i>
@@ -14,7 +14,7 @@
   {{ end }}
 
   {{ with $pag.Next }}
-  <a class="next" href="{{ .RelPermalink }}">
+  <a class="next" href="{{ .URL }}">
     <span class="next-text">{{ i18n "next" }}</span>
       <i class="iconfont">
         {{ partial "svg/right.svg" }}


### PR DESCRIPTION
This probably fixes #222.

The current master version does not build when `paginateOriginalStyle = true`.