### PR TITLE
Fix: empty homepage or wrong posts list

### DIFF
--- a/dev-config.toml
+++ b/dev-config.toml
@@ -6,6 +6,8 @@ baseURL = "https://www.xianmin.org/hugo-theme-jane/"
 enableRobotsTXT = true
 enableEmoji = true
 
+mainSections = ["post"]
+
 hasCJKLanguage = true     # has chinese/japanese/korean ? # 自动检测是否包含 中文\日文\韩文
 paginate = 5                                              # 首页每页显示的文章数
 rssLimit = 20             # Limit Entry Count to Rss file # 限制 Rss 文章输出数量

--- a/exampleSite/full-config.toml
+++ b/exampleSite/full-config.toml
@@ -70,6 +70,7 @@ defaultContentLanguage = "en"           # Default language to use
   since = "2017"            # Site creation time          # 站点建立时间
   homeFullContent = false   # if false, show post summaries on home page. Othewise show full content.
   rssFullContent = true     # if false, Rss feed instead of the summary
+  mainSections = ["post"]
 
   # site info (optional)                                  # 站点信息（可选，不需要的可以直接注释掉）
   logoTitle = "Jane"        # default: the title value    # 默认值: 上面设置的title值

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,13 +1,16 @@
 {{ define "content" }}
-  <section id="posts" class="posts">
-    {{/* (index .Site.Paginate) */}}
-    {{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
-    {{ range $paginator.Pages }}
-      {{ .Render "summary" }}
-    {{ end }}
-  </section>
+<section id="posts" class="posts">
+  {{ $pages := .Pages }}
+  {{ if .IsHome }}
+    {{ $pages = where .Site.RegularPages "Type" "in" site.Params.mainSections }}
+  {{ end }}
+  {{ $paginator := .Paginate $pages }}
+  {{ range $paginator.Pages }}
+    {{ .Render "summary" }}
+  {{ end }}
+</section>
 
-  <!-- pagination -->
-  {{ partial "pagination.html" . }}
+<!-- pagination -->
+{{ partial "pagination.html" . }}
 
 {{ end }}


### PR DESCRIPTION
 Hugo v.0.57.0 存在打破性更改，修复首页文章列表相关内容

关于此PR的官方警告：[Demos with empty homepage and/or wrong posts list](https://github.com/gohugoio/hugoThemes/issues/682)