### PR TITLE
Add Stackbit Integration

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -190,3 +190,8 @@ npm run dev
 Hugo-theme-jane is licensed under the MIT license. Check the [LICENSE](LICENSE.md) file for details.
 
 
+# Stackbit
+
+This theme is ready to import into Stackbit. This theme can be deployed to Netlify and you can connect any headless CMS including Forestry, NetlifyCMS, DatoCMS or Contentful. 
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/xianmin/hugo-theme-jane)

--- a/README.md
+++ b/README.md
@@ -200,3 +200,9 @@ This project follows the [all-contributors](https://github.com/kentcdodds/all-co
 ## License
 
 Hugo-theme-jane is licensed under the MIT license. Check the [LICENSE](LICENSE.md) file for details.
+
+# Stackbit
+
+This theme is ready to import into Stackbit. This theme can be deployed to Netlify and you can connect any headless CMS including Forestry, NetlifyCMS, DatoCMS or Contentful. 
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/xianmin/hugo-theme-jane)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build.environment]
+  HUGO_VERSION = "0.55.6"
+  HUGO_THEME = "repo"
+  HUGO_BASEURL = "/"

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -250,6 +250,9 @@ models:
         name: title
         label: Blog Title
       - type: string
+        name: description
+        label: Description
+      - type: string
         name: author
         label: Blog Author
       - type: datetime

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,343 @@
+stackbitVersion: ~0.2.0
+ssgName: custom
+publishDir: exampleSite/public
+buildCommand: cd exampleSite && hugo --gc --baseURL "/" --themesDir ../.. && cd ..
+uploadDir: images
+staticDir: static
+pagesDir: exampleSite/content
+dataDir: exampleSite
+models:
+  config:
+    type: data
+    label: Config
+    file: config.toml
+    fields:
+      - type: string
+        name: title
+        label: Title
+      - type: string
+        name: baseURL
+        label: Base URL
+        description: Hostname (and path)  to the root
+      - type: boolean
+        name: enableRobotsTXT
+        label: Enable Robots Text
+      - type: boolean
+        name: enableEmoji
+        label: Enable Emoji
+      - type: string
+        name: theme
+        label: Theme name
+      - type: boolean
+        name: hasCJKLanguage
+        label: Has CJK Language
+      - type: number
+        name: paginate
+        label: Paginate
+        description:  Number of articles displayed on the homepage
+      - type: number
+        name: rssLimit
+        label: Rss Limint
+        description: Limit Entry Count to Rss file
+      - type: string
+        name: disqusShortname
+        label: Disqus Shortname
+      - type: string
+        name: googleAnalytics
+        label: Google Analytics code
+      - type: string
+        name: copyright
+        label: Copyright
+      - type: string
+        name: defaultContentLanguage
+        label: Default Content Language
+      - type: object
+        name: languages
+        label: Languages
+        fields: 
+          - type: object
+            name: en
+            label: English
+            fields:
+              - type: string
+                name: languageCode
+                label: Language code
+      - type: object
+        name: author
+        label: Author
+        fields:
+          - type: string
+            name: name
+            label: Name
+      - type: object
+        name: sitemap
+        label: Sitemap
+        fields: 
+          - type: string
+            name: changefreq
+            label: Change frequency
+          - type: number
+            subtype: float
+            name: priority
+            label: Priority
+          - type: string
+            name: filename
+            label: Filename
+      - type: object
+        name: menu
+        label: Menu
+        fields:
+          - type: list
+            name: main
+            label: Main Menu
+            items:
+              type: object
+              fields:
+                - type: string
+                  name: name
+                  label: Menu Name
+                - type: number
+                  name: weight
+                  label: Page order weight
+                - type: string
+                  name: identifier
+                  label: Identifier
+                - type: string
+                  name: url
+                  label: Menu Link
+      - type: object
+        name: params
+        label: Site Parameters
+        fields:
+          - type: string
+            name: since
+            label: Since
+            description: Site Creation Time
+          - type: boolean
+            name: homeFullContent
+            label: Home Full Content
+            description: if false, show post summaries on home page. Othewise show full content.
+          - type: boolean
+            name: rssFullContent
+            label: Rss Full Content
+            description: if false, Rss feed instead of the summary
+          - type: string
+            name: logoTitle
+            label: Logo Title
+          - type: list
+            name: keywords 
+            label: Keywords
+            items:
+              type: string
+          - type: string
+            name: description
+            label: description
+          - type: string
+            name: dateFormatToUse
+            label: Date Format
+          - type: boolean
+            name: toc
+            label: TOC
+          - type: boolean
+            name: photoswipe
+            label: Photo Swipe
+          - type: string
+            name: contentCopyright
+            label: Content Copyright
+          - type: list
+            name: customCSS
+            label: Custom Css
+            description: if ['custom.css'], load '/static/css/custom.css' fileif ['custom.css'], load '/static/css/custom.css' file
+            items:
+              type: string
+          - type: list
+            name: customJS
+            label: Custom JS
+            description: if ['custom.js'], load '/static/js/custom.js' file
+            items:
+              type: string
+          - type: object
+            name: social
+            label: Social
+            fields:
+              - type: string
+                name: a-email
+                label: Email
+              - type: string
+                name: b-stack-overflow
+                label: StackOverflow
+              - type: string
+                name: c-twitter
+                label: Twitter
+              - type: string
+                name: d-facebook
+                label: Facebook
+              - type: string
+                name: e-linkedin
+                label: Linkedin
+              - type: string
+                name: f-google
+                label: Google
+              - type: string
+                name: g-github
+                label: Github
+              - type: string
+                name: h-weibo
+                label: Weibo
+              - type: string
+                name: i-zhihu
+                label: Zhihu
+              - type: string
+                name: j-douban
+                label: Douban
+              - type: string
+                name: k-pocket
+                label: Pocket
+              - type: string
+                name: l-tumblr
+                label: Tumblr
+              - type: string
+                name: m-instagram
+                label: Instagram
+              - type: string
+                name: n-gitlab
+                label: Gitlab
+              - type: string
+                name: o-goodreads
+                label: Goodreads
+              - type: string
+                name: p-coding
+                label: Coding
+              - type: string
+                name: q-bilibili
+                label: Bilibili
+              - type: string
+                name: r-codeforces
+                label: Codeforces
+  basicpage:
+    type: page
+    label: Basic page
+    match: "*.md"
+    fields: 
+      - type: string
+        name: title
+        label: Title
+      - type: datetime
+        name: date
+        label: Publish Date
+      - type: datetime
+        name: lastmod
+        label: Last Modified Date
+      - type: string
+        name: menu
+        label: Menu
+      - type: number
+        name: weight
+        label: Page Order weight
+      - type: boolean
+        name: comment
+        label: Comment
+      - type: boolean
+        name: mathjax
+        label: Mathjax
+        description: see https://www.mathjax.org/
+  post:
+    type: page
+    label: Blog posts
+    folder: post
+    fields: 
+      - type: string
+        name: title
+        label: Blog Title
+      - type: string
+        name: author
+        label: Blog Author
+      - type: datetime
+        name: date
+        label: Publish date
+      - type: datetime
+        name: lastmod
+        label: Last Modified Date
+      - type: list
+        name: tags
+        label: Tags
+        items:
+          type: string
+      - type: list
+        name: categories
+        label: Categories
+        items:
+          type: string
+      - type: boolean
+        name: draft
+        label: Draft
+      - type: boolean
+        name: comment
+        label: Comment
+      - type: boolean
+        name: toc
+        label: Toc
+      - type: boolean
+        name: autoCollapseToc
+        label: Auto Collaps Toc
+      - type: string
+        name: contentCopyright
+        label: Content Copyright
+      - type: boolean
+        name: reward
+        label: Reward
+      - type: boolean
+        name: mathjax
+        label: Mathjax
+        description: see https://www.mathjax.org/
+      - type: number
+        name: weight
+        label: Weight
+      - type: object
+        name: menu
+        label: Menu
+        fields:
+          - type: object
+            name: main
+            label: Main
+            fields: 
+              - type: string
+                name: parent
+                label: Parent Menu
+              - type: number
+                name: weight
+                label: Weight
+  authors:
+    type: data
+    label: Authors Data
+    file: data/authors/ted.toml
+    fields: 
+      - type: string
+        name: description
+        label: Description
+      - type: object
+        name: name
+        label: Name
+        fields:
+          - type: string
+            name: display
+            label: Display
+      - type: object
+        name: image
+        label: Image
+        fields:
+          - type: image
+            name: url
+            label: Image
+          - type: number
+            name: width
+            label: Image Width
+          - type: number
+            name: height
+            label: Image Height
+
+
+  
+
+
+


### PR DESCRIPTION
This pull request add's Stackbit to this Hugo theme. It add's the stackbit.yaml file which makes this theme work with several headless CMS automatically (including Forestry, NetlifyCMS, DatoCMS & Contentful) and it deploys the site to Netlify in 1 click.

You can try it out: https://app.stackbit.com/create?theme=https://github.com/stackbithq/hugo-theme-jane (note the "create with stackbit" button in the readme will import the theme from your repo so until the PR is merged it wont work)

I think this is really valuable and is a very low impact addition on your existing theme structure. Pretty much just the stackbit.yaml file. If you have questions or feedback I'm happy to discuss.

Risto