### PR TITLE
set default layout for taxonomies

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,4 +1,4 @@
-{{ define "title" }}{{ i18n .Data.Plural }} - {{ .Site.Title }}{{ end }}
+{{ define "title" }}{{ i18n .Data.Plural | default (title .Data.Plural ) }} - {{ .Site.Title }}{{ end }}
 
 {{ define "content" }}
   {{ $termName := .Data.Singular }}
@@ -114,6 +114,40 @@
       </section>
     {{ end }}
     {{ end }}
+  {{ else }}
+  {{ range $terms }}
+    {{ $term := .Term }}
+    {{ $pages := .Pages }}
+    {{ with $.Site.GetPage "taxonomy" (printf "%s/%s" $type $term)}}
+    <section id="archive" class="archive">
+      <div class="archive-title"></div>
+      <div class="collection-title">
+        <h2 class="archive-year">
+          <a href="{{ .Permalink }}">
+            {{ i18n $termName | default (printf "%s: " (title $termName)) }}{{ $term }}
+          </a>
+        </h2>
+      </div>
+      {{ range first 5 $pages }}
+            <div class="archive-post">
+              <time datetime="{{ .Date.Format "2006-01-02" }}" class="archive-post-time">
+                {{ .Date.Format "2006-01-02" }}
+              </time>
+              <span class="archive-post-title">
+                <a href="{{ .RelPermalink }}" class="archive-post-link">
+                  {{ .Title }}
+                </a>
+              </span>
+            </div>
+          {{ end }}
+          {{ if gt (len $pages) 5 }}
+            <div class="more-post">
+              <a href="{{ .Permalink }}" class="more-post-link">{{ i18n "morePost" }}</a>
+            </div>
+          {{ end }}
+    </section>
+    {{ end }}
+  {{ end }}
 
   {{ end }}
 


### PR DESCRIPTION
This PR adds a default layout for taxonomies.

Before this PR, when we add a new taxonomy(like "collection"), we will get an empty page at `domain/collections` which is really confusing and awkward.

With this PR, we will get a default layout just like `Category` and the leading title will be taxonomy itself.

This PR also sets the default i18n content of the taxonomy to the content itself. So that we don't need to update all the i18n files every time we add a new taxonomy.

I'm new to hugo and wonder if there's a better way to do this.