### PR TITLE
Remove google_news usage

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -85,7 +85,6 @@
 
 {{/* NOTE: These Hugo Internal Templates can be found starting at https://github.com/spf13/hugo/blob/master/tpl/tplimpl/template_embedded.go#L158 */}}
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 


### PR DESCRIPTION
Deprecated here: https://github.com/gohugoio/hugo/issues/9172

Causes the following warning:

```
[opc@terrty ~/blog]$ docker-compose run build
Start building sites …
hugo v0.95.0-9F2E76AF linux/arm64 BuildDate=2022-03-16T14:20:19Z VendorInfo=gohugoio
WARN 2022/03/28 22:11:03 The google_news internal template will be removed in a future release. Please remove calls to this template. See https://github.com/gohugoio/hugo/issues/9172 for additional information.
```