### PR TITLE
Add Remark42 comments support

### DIFF
--- a/exampleSite/full-config.toml
+++ b/exampleSite/full-config.toml
@@ -123,6 +123,13 @@ defaultContentLanguage = "en"           # Default language to use
   # add custom info on the footer.   # 添加备案信息
   # customFooter = "京ICP备10000000号-1"
 
+  # Remark42 is self-hosted privacy-focused comment system, https://remark42.com
+  remark42Url = "https://remark42.example.com"
+  remark42SiteId = "remark"
+
+  [params.commentCount.remark42] # enable "comment count" feature for remark42, requires moreMeta param to be enabled as well
+    enable = true
+
   [params.publicCDN]        # load these files from public cdn                          # 启用公共CDN，需自行定义
     enable = false
     jquery = '<script src="https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>'

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -140,13 +140,19 @@
         el: '#comments' ,
         appId: '{{ .Site.Params.valine.appId }}',
         appKey: '{{ .Site.Params.valine.appKey }}',
-        notify: {{ .Site.Params.valine.notify }}, 
-        verify: {{ .Site.Params.valine.verify }}, 
-        avatar:'{{ .Site.Params.valine.avatar }}', 
+        notify: {{ .Site.Params.valine.notify }},
+        verify: {{ .Site.Params.valine.verify }},
+        avatar:'{{ .Site.Params.valine.avatar }}',
         placeholder: '{{ .Site.Params.valine.placeholder }}',
         visitor: {{ false }}
     });
   </script>
   {{- end }}
+
+  <!-- Remark42 -->
+  {{- if .Site.Params.remark42Url -}}
+  <div id="remark42"></div>
+  {{- end }}
+
 
 {{- end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <div class="icon-links">
-  {{ partial "social_links.html" . }} 
+  {{ partial "social_links.html" . }}
 </div>
 
 <div class="copyright">

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -242,6 +242,22 @@
   <script id="dsq-count-scr" src="//{{ .Site.DisqusShortname }}.disqus.com/count.js" async></script>
 {{ end }}
 
+{{ if .Site.Params.remark42Url }}
+<script>
+  var remark_config = {
+    host: '{{ .Site.Params.remark42Url }}',
+    site_id: '{{ .Site.Params.remark42SiteId | default "remark" }}',
+    components: [
+	    'embed',
+{{ if and .Site.Params.commentCount.remark42.enable (not .Page.IsPage) -}}
+	    'counter',
+{{- end }}
+    ],
+  }
+  !function(e,n){for(var o=0;o<e.length;o++){var r=n.createElement("script"),c=".js",d=n.head||n.body;"noModule"in r?(r.type="module",c=".mjs"):r.async=!0,r.defer=!0,r.src=remark_config.host+"/web/"+e[o]+c,d.appendChild(r)}}(remark_config.components||["embed"],document);
+</script>
+{{ end }}
+
 {{ if .Site.Params.search.google.enable }}
   <script>
     $("#openSearch, #openSearchMobile").click(function(){

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -26,9 +26,15 @@
       {{ if .Site.Params.moreMeta -}}
       <span class="more-meta"> {{ i18n "wordCount" .WordCount }} </span>
       <span class="more-meta"> {{ i18n "readingTime" .ReadingTime }} </span>
-      {{ if .Site.Params.commentCount.disqus.enable }}
+        {{ if .Site.Params.commentCount.disqus.enable }}
         <span class="more-meta"> <a href="{{ .Permalink }}#disqus_thread">{{ i18n "comments" }}</a> </span>
-      {{ end }}
+        {{ end }}
+        {{ if .Site.Params.commentCount.remark42.enable }}
+        <span class="more-meta"><span
+         class="remark42__counter"
+         data-url="{{ .Permalink }}"
+        ></span></span> {{ i18n "comments" }}
+        {{ end }}
       {{- end }}
       <!-- Counter leancloud -->
       {{ if .Site.Params.counter.leancloud.enable }}

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -37,7 +37,7 @@ models:
         description:  Number of articles displayed on the homepage
       - type: number
         name: rssLimit
-        label: Rss Limint
+        label: Rss Limit
         description: Limit Entry Count to Rss file
       - type: string
         name: disqusShortname
@@ -54,7 +54,7 @@ models:
       - type: object
         name: languages
         label: Languages
-        fields: 
+        fields:
           - type: object
             name: en
             label: English
@@ -72,7 +72,7 @@ models:
       - type: object
         name: sitemap
         label: Sitemap
-        fields: 
+        fields:
           - type: string
             name: changefreq
             label: Change frequency
@@ -125,7 +125,7 @@ models:
             name: logoTitle
             label: Logo Title
           - type: list
-            name: keywords 
+            name: keywords
             label: Keywords
             items:
               type: string
@@ -144,6 +144,33 @@ models:
           - type: string
             name: contentCopyright
             label: Content Copyright
+          - type: boolean
+            name: moreMeta
+            label: Shows word count and read time and comments count (if enabled)
+          - type: string
+            name: remark42Url
+            label: Remark42 URL
+          - type: string
+            name: remark42SiteId
+            label: Remark42 Site ID, optional, `remark` by default
+          - type: object
+            name: commentCount
+            label: Comment Count settings (requires moreMeta to be enabled to work)
+            fields:
+              - type: object
+                name: disqus
+                label: Disqus
+                fields:
+                  - type: boolean
+                    name: enable
+                    label: Enable Disqus comment count
+              - type: object
+                name: remark42
+                label: Remark42
+                fields:
+                  - type: boolean
+                    name: enable
+                    label: Enable Remark42 comment count
           - type: list
             name: customCSS
             label: Custom Css
@@ -221,7 +248,7 @@ models:
     type: page
     label: Basic page
     match: "*.md"
-    fields: 
+    fields:
       - type: string
         name: title
         label: Title
@@ -248,7 +275,7 @@ models:
     type: page
     label: Blog posts
     folder: post
-    fields: 
+    fields:
       - type: string
         name: title
         label: Blog Title
@@ -314,7 +341,7 @@ models:
           - type: object
             name: main
             label: Main
-            fields: 
+            fields:
               - type: string
                 name: parent
                 label: Parent Menu
@@ -325,7 +352,7 @@ models:
     type: data
     label: Authors Data
     file: data/authors/ted.toml
-    fields: 
+    fields:
       - type: string
         name: description
         label: Description
@@ -349,9 +376,3 @@ models:
           - type: number
             name: height
             label: Image Height
-
-
-  
-
-
-


### PR DESCRIPTION
These changes are live on https://terrty.net, here is how comments and counter looks like:
<img width="935" alt="image" src="https://user-images.githubusercontent.com/712534/163736950-6325f307-238d-4878-b077-2e2b19cb0e44.png">
<img width="892" alt="image" src="https://user-images.githubusercontent.com/712534/163736967-12c0d393-70e1-4052-81fb-27e91ce637d9.png">

Configuration options are taken from how Disqus comments work now in that theme.