### PR TITLE
Don't embed remark42 on pages without comments form

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -242,14 +242,15 @@
   <script id="dsq-count-scr" src="//{{ .Site.DisqusShortname }}.disqus.com/count.js" async></script>
 {{ end }}
 
-{{ if .Site.Params.remark42Url }}
+{{ if and .Site.Params.remark42Url (or .Page.IsPage .IsHome) }}
 <script>
   var remark_config = {
     host: '{{ .Site.Params.remark42Url }}',
     site_id: '{{ .Site.Params.remark42SiteId | default "remark" }}',
     components: [
+{{- if .Page.IsPage }}
 	    'embed',
-{{ if and .Site.Params.commentCount.remark42.enable (not .Page.IsPage) -}}
+{{- else if and .Site.Params.commentCount.remark42.enable .IsHome }}
 	    'counter',
 {{- end }}
     ],


### PR DESCRIPTION
I've made misconfiguration while embedding remark42, this PR fixes it. Now remark42 configuration won't be loaded on pages where neither comment form nor comments counter are present.