### PR TITLE
rm leading slash for relURL

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -92,7 +92,7 @@
 
 <!-- custom css -->
 {{ range .Site.Params.customCSS }}
-<link rel="stylesheet" href="{{ "/css/" | relURL }}{{ . }}">
+<link rel="stylesheet" href="{{ "css/" | relURL }}{{ . }}">
 {{ end }}
 
 {{/* NOTE: These Hugo Internal Templates can be found starting at https://github.com/spf13/hugo/blob/master/tpl/tplimpl/template_embedded.go#L158 */}}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -279,5 +279,5 @@
 
 <!-- custom js -->
 {{ range .Site.Params.customJS }}
-  <script src="{{ "/js/" | relURL }}{{ . }}"></script>
+  <script src="{{ "js/" | relURL }}{{ . }}"></script>
 {{ end }}

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -4,7 +4,7 @@ NB this overrides Hugo's built-in "figure" shortcode but is backwards compatible
 Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 -->
 <!-- count how many times we've called this shortcode; load the css if it's the first time -->
-{{- if not ($.Page.Scratch.Get "figurecount") }}<link rel="stylesheet" href="{{ "/css/hugo-easy-gallery.css" | relURL }}" />{{ end }}
+{{- if not ($.Page.Scratch.Get "figurecount") }}<link rel="stylesheet" href="{{ "css/hugo-easy-gallery.css" | relURL }}" />{{ end }}
 {{- $.Page.Scratch.Add "figurecount" 1 -}}
 <!-- use either src or link-thumb for thumbnail image -->
 {{- $thumb := .Get "src" | default (printf "%s." (.Get "thumb") | replace (.Get "link") ".") }}


### PR DESCRIPTION
Check https://gohugo.io/functions/relurl/#input-begins-with-a-slash for details.

> If the input begins with a slash, the resulting URL will be incorrect when the baseURL includes a subdirectory. With a leading slash, the function returns a URL relative to the protocol+host section of the baseURL.

As a result, the customJS and customCSS feature was broken when baseURL includes a subdirectory like `https://example.com/blog`.
