### PR TITLE
Add instructions about installing theme as a hugo module

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ cd myBlog
 git clone https://github.com/xianmin/hugo-theme-jane.git --depth=1 themes/jane
 ```
 
+<details>
+<summary>Alternative, installation as a module</summary>
+
+If you have [Go](https://go.dev/) installed you can install the theme as a [hugo module](https://gohugo.io/hugo-modules/), then there will be no need to clone it into the `themes` folder:
+
+```bash
+hugo mod init example.com/my-blog
+```
+
+After that, you would need to use `github.com/xianmin/hugo-theme-jane` as your `theme` and not `hugo-theme-jane` in your `config.toml` file.
+
+</details>
+
 Copy the example site content:
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/xianmin/hugo-theme-jane
+
+go 1.21.0


### PR DESCRIPTION
Technically go.mod is not necessary but it's nice to have. The instruction as a module works right now without go.mod added.