### PR TITLE
Re-add Remark42 and Disqus comment counter

### DIFF
--- a/layouts/partials/post/meta.html
+++ b/layouts/partials/post/meta.html
@@ -36,6 +36,15 @@
       <span class="post-meta-more">
         {{ i18n "wordCount" .WordCount }} -
         {{ i18n "readingTime" .ReadingTime }}
+      {{ if and .Site.Params.commentCount.disqus.enable .Site.GetPage.IsHome }}
+        - <a href="{{ .Permalink }}#disqus_thread">{{ i18n "comments" }}</a>
+      {{ end }}
+      {{- if and .Site.Params.commentCount.remark42.enable .Site.GetPage.IsHome }}
+        - <span
+            class="remark42__counter"
+            data-url="{{ .Permalink }}"
+          ></span> {{ i18n "comments" }}
+      {{ end -}}
       </span>
     {{- end }}
 

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -63,7 +63,7 @@
   (function() {
     if (window.location.hostname === 'localhost') return;
     var hm = document.createElement("script"); hm.async = true;
-	hm.src = "//tajs.qq.com/stats?sId={{.}}";
+    hm.src = "//tajs.qq.com/stats?sId={{.}}";
     var s = document.getElementsByTagName("script")[0];
     s.parentNode.insertBefore(hm, s);
   })();
@@ -112,7 +112,7 @@
       crossorigin="anonymous"></script>
   {{ else if .Site.Params.publicCDN.enable }}
     <script type="text/javascript" src="{{ "js/load-photoswipe.js" | relURL }}"></script>
-	{{ .Site.Params.publicCDN.photoswipe | safeHTML }}
+    {{ .Site.Params.publicCDN.photoswipe | safeHTML }}
     {{ .Site.Params.publicCDN.photoswipeUI | safeHTML }}
   {{ else }}
     <script type="text/javascript" src="{{ "lib/photoswipe/photoswipe.min.js" | relURL}}"></script>
@@ -247,10 +247,10 @@
     host: '{{ .Site.Params.remark42Url }}',
     site_id: '{{ .Site.Params.remark42SiteId | default "remark" }}',
     components: [
-{{- if .Page.IsPage }}
-	    'embed',
-{{- else if and .Site.Params.commentCount.remark42.enable .IsHome }}
-	    'counter',
+{{- if not .IsHome }}
+    'embed',
+{{- else if .Site.Params.commentCount.remark42.enable }}
+    'counter',
 {{- end }}
     ],
   }


### PR DESCRIPTION
It was deleted in 7bb41658, likely by accident. Here is how it looks like after changes:

<img width="903" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/a3a7324c-8661-4d2d-aae0-47e18edf28c0">
