### PR TITLE
respect local format in the render

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -23,7 +23,7 @@
 
     <div class="archive-post">
       <time datetime="{{ .Date.Format "2006-01-02" }}" class="archive-post-time">
-        {{ .Date.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }}
+        {{ .Date | time.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }}
       </time>
       <span class="archive-post-title">
         <a href="{{ $element.RelPermalink }}" class="archive-post-link">

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -34,7 +34,7 @@
   {{ range $paginator.Pages }}
     <div class="archive-post">
       <time datetime="{{ .Date.Format "2006-01-02" }}" class="archive-post-time">
-        {{ .Date.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }}
+        {{ .Date | time.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }}
       </time>
       <span class="archive-post-title">
         <a href="{{ .RelPermalink }}" class="archive-post-link">

--- a/layouts/partials/post/copyright.html
+++ b/layouts/partials/post/copyright.html
@@ -17,7 +17,7 @@
   <p class="copyright-item">
     <span class="item-title">{{ i18n "lastMod" }}</span>
     <span class="item-content">
-      {{ .Lastmod.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }}
+      {{ .Lastmod | time.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }}
       {{ with .GitInfo }}
         {{ if $.Site.Params.gitInfo.gitRepo -}}
         <a href="{{ $.Site.Params.gitInfo.gitRepo }}/commit/{{ .Hash }}" title="{{ .Subject }}">

--- a/layouts/partials/post/meta.html
+++ b/layouts/partials/post/meta.html
@@ -19,14 +19,14 @@
 
   <div class="post-meta-time">
     <time datetime="{{ .Date.Format "2006-01-02" }}">
-      {{ .Date.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }}
+      {{ .Date | time.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }}
     </time>
   </div>
 
   {{ if ne (.Lastmod.Format ("2006-01-02")) (.Date.Format ("2006-01-02")) }}
     <div class="post-meta-lastmod">
       ({{ i18n "lastMod" }}:
-      {{ .Lastmod.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }})
+      {{ .Lastmod | time.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }})
     </div>
   {{ end }}
 


### PR DESCRIPTION
Previously, time representation in English was always used. Examples with Spanish below.

Post title. Before:
<img width="722" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/b6b6c81c-3b13-4731-99a3-19c4d1d3423e">
After:
<img width="708" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/c8f023da-726e-4b65-a375-1e5c32dec41d">
---
Copyright. Before:
<img width="712" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/b38b4e89-c5da-4033-9d4e-4dd76cbeac18">
After:
<img width="719" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/f446549e-a258-465b-ad18-7847e2287bf1">
---
Posts archive. Before:
<img width="683" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/7ea131d8-8969-418b-b2fa-9aab99e92902">
After:
<img width="775" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/eb24fa1f-bd10-49a1-b6f2-34c2e8178c78">
Tag page. Before:
<img width="705" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/b0812fa4-8c04-4df9-9536-6107228daba0">
After:
<img width="768" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/91ff9c44-7097-4d74-9253-a25dbde9980d">
