### PR TITLE
Fix Remark42 comments count on the post page

### DIFF
--- a/layouts/partials/post/meta.html
+++ b/layouts/partials/post/meta.html
@@ -39,7 +39,7 @@
       {{ if and .Site.Params.commentCount.disqus.enable .Site.GetPage.IsHome }}
         - <a href="{{ .Permalink }}#disqus_thread">{{ i18n "comments" }}</a>
       {{ end }}
-      {{- if and .Site.Params.commentCount.remark42.enable .Site.GetPage.IsHome }}
+      {{- if .Site.Params.commentCount.remark42.enable }}
         - <span
             class="remark42__counter"
             data-url="{{ .Permalink }}"

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -249,7 +249,8 @@
     components: [
 {{- if not .IsHome }}
     'embed',
-{{- else if .Site.Params.commentCount.remark42.enable }}
+{{- end }}
+{{- if .Site.Params.commentCount.remark42.enable }}
     'counter',
 {{- end }}
     ],


### PR DESCRIPTION
Previously, the comment counter was supposed to be displayed but did not. Now, it would work the same with the list of posts
and on the single post page.

Before and after, the main page:
<img width="813" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/3e94e5d3-0393-488c-8ae5-48d52fa2243f">

Before, the post page:
<img width="812" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/144d1771-c162-4f6b-b23b-d83a4332aba4">

After, the post page:
<img width="827" alt="image" src="https://github.com/xianmin/hugo-theme-jane/assets/712534/0a620b48-cb13-44b6-9ea7-0d5b7d627529">

I presume when I added it initially, I thought the counter shouldn't be displayed on the post page. However, in reality, it is displayed, but JS code loading digits were not enabled.
