### PR TITLE
Update MathJax and put it in a separate partial layout that can be overridden

### DIFF
--- a/layouts/partials/mathjax.html
+++ b/layouts/partials/mathjax.html
@@ -1,0 +1,2 @@
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -18,13 +18,7 @@
 
 <!-- Mathjax -->
 {{- if and (or .Params.mathjax (and .Site.Params.mathjax (ne .Params.mathjax false))) (or .IsPage .IsHome) }}
-  <script type="text/javascript">
-    window.MathJax = {
-      showProcessingMessages: false,
-      messageStyle: 'none'
-    };
-  </script>
-  <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML' async></script>
+  {{ partialCached "mathjax.html" . }}
 {{- end }}
 <!-- End -->
 


### PR DESCRIPTION
Fixes #377 while also making it possible to stick to MathJax 2 if desired.