### PR TITLE
Fix: Photoswipe was not loaded when not using CDN

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -98,14 +98,13 @@
 
 <!-- Load PhotoSwipe js if the load-photoswipe shortcode has been used -->
 {{ if or .Site.Params.photoswipe .Site.Params.fancybox }}
+  <script type="text/javascript" src="{{ "js/load-photoswipe.js" | relURL }}"></script>
   {{ if .Site.Params.bootcdn }}
-    <script src="{{ "js/load-photoswipe.js" | relURL }}"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe.min.js" integrity="sha256-UplRCs9v4KXVJvVY+p+RSo5Q4ilAUXh7kpjyIP5odyc="
       crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe-ui-default.min.js" integrity="sha256-PWHOlUzc96pMc8ThwRIXPn8yH4NOLu42RQ0b9SpnpFk="
       crossorigin="anonymous"></script>
   {{ else if .Site.Params.publicCDN.enable }}
-    <script type="text/javascript" src="{{ "js/load-photoswipe.js" | relURL }}"></script>
     {{ .Site.Params.publicCDN.photoswipe | safeHTML }}
     {{ .Site.Params.publicCDN.photoswipeUI | safeHTML }}
   {{ else }}


### PR DESCRIPTION
If neither bootcdn, nor publicCDN is set to true, PhotoSwipe won't load. Most likely initialization script was removed by mistake.