### PR TITLE
Fix use of deprecated symbols

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -21,7 +21,7 @@
   {{- end }}
 
   <!-- Disqus -->
-  {{- if .Site.DisqusShortname -}}
+  {{- if .Site.Config.Services.Disqus.Shortname -}}
     {{ partial "comments/disqus.html" . }}
   {{- end }}
 

--- a/layouts/partials/comments/disqus.html
+++ b/layouts/partials/comments/disqus.html
@@ -13,7 +13,7 @@
       if (window.location.hostname === 'localhost') return;
 
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      var disqus_shortname = '{{ .Site.DisqusShortname }}';
+      var disqus_shortname = '{{ .Site.Config.Services.Disqus.Shortname }}';
       dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -111,7 +111,7 @@
 <![endif]-->` | safeHTML }}
 
 <!-- Analytics -->
-{{- if and (not .Site.IsServer) .Site.GoogleAnalytics -}}
+{{- if and (not hugo.IsServer) .Site.Config.Services.GoogleAnalytics.ID -}}
   {{ template "_internal/google_analytics.html" . }}
 {{- end -}}
 

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -232,7 +232,7 @@
 {{ end }}
 
 {{ if .Site.Params.commentCount.disqus.enable }}
-  <script id="dsq-count-scr" src="//{{ .Site.DisqusShortname }}.disqus.com/count.js" async></script>
+  <script id="dsq-count-scr" src="//{{ .Site.Config.Services.Disqus.Shortname }}.disqus.com/count.js" async></script>
 {{ end }}
 
 {{ if and .Site.Params.remark42Url (or .Page.IsPage .IsHome) }}


### PR DESCRIPTION
    ERROR deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use hugo.IsServer instead.
    ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.
    ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use .Site.Config.Services.Disqus.Shortname instead.