### PR TITLE
style: only add delimiters between categories

### DIFF
--- a/assets/sass/_partial/_post/_header.scss
+++ b/assets/sass/_partial/_post/_header.scss
@@ -63,7 +63,7 @@
       display: inline;
 
       a {
-        &::before {
+        &:not(:first-child)::before {
           content: "·";
         }
       }


### PR DESCRIPTION
Before:

![Screenshot_20240926_092129](https://github.com/user-attachments/assets/a1566737-8c46-441d-90bb-986367dee952)


After:

![Screenshot_20240926_092052](https://github.com/user-attachments/assets/1eb66854-9e2e-4c80-b53c-8621a7d6f57e)
