### PR TITLE
fix: restore per-post author override functionality

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -69,9 +69,9 @@
     </article>
 
     <!-- Author Info -->
-    {{ if and (.Site.Params.author.name | default .Site.Author.name) (.Params.showAuthorInfo | default
+    {{ if and ( .Params.author | default .Site.Params.author.name | default .Site.Author.name) (.Params.showAuthorInfo | default
     .Site.Params.showAuthorInfo) }}
-    {{ partial "author_info.html" (dict "author" (.Site.Params.author.name | default .Site.Author.name) "context" $) }}
+    {{ partial "author_info.html" (dict "author" (.Params.author | default .Site.Params.author.name | default .Site.Author.name) "context" $) }}
     {{ end }}
 
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -35,8 +35,8 @@ see : https://ziyuan.baidu.com/college/courseinfo?id=156
 <meta name="mobile-web-app-capable" content="yes">
 
 <!-- author & description & keywords  -->
-{{- if or .Site.Params.author.name .Site.Author.name -}}
-{{- $author_id := .Site.Params.author.name | default .Site.Author.name -}}
+{{- if or .Params.author .Site.Params.author.name .Site.Author.name -}}
+{{- $author_id := .Params.author | default .Site.Params.author.name | default .Site.Author.name -}}
 {{- $author := (index ($.Site.Data.authors | default dict) $author_id) -}}
 {{- $author_lang := (index ($author | default dict) .Site.Language.Lang) -}}
 {{- $author_name := $author_lang.name.display | default $author.name.display | default $author_id -}}

--- a/layouts/partials/post/copyright.html
+++ b/layouts/partials/post/copyright.html
@@ -3,7 +3,7 @@
   <p class="copyright-item">
     <span class="item-title">{{ i18n "author" }}</span>
     <span class="item-content">
-      {{- $author_id := .Site.Params.author.name | default .Site.Author.name -}}
+      {{- $author_id := .Params.author | default .Site.Params.author.name | default .Site.Author.name -}}
       {{- $author := (index ($.Site.Data.authors | default dict) $author_id) -}}
       {{- $author_lang := (index ($author | default dict) .Site.Language.Lang) -}}
       {{- $author_name := $author_lang.name.display | default $author.name.display | default $author_id -}}

--- a/layouts/partials/post/meta.html
+++ b/layouts/partials/post/meta.html
@@ -9,7 +9,7 @@
     {{ partial "icons/icon" (dict
     "path" "icons/post/author.svg"
     ) }}
-    {{- $author_id := .Site.Params.author.name | default .Site.Author.name -}}
+    {{- $author_id := .Params.author | default .Site.Params.author.name | default .Site.Author.name -}}
     {{- $author := (index ($.Site.Data.authors | default dict) $author_id) -}}
     {{- $author_lang := (index ($author | default dict) .Site.Language.Lang) -}}
     {{- $author_name := $author_lang.name.display | default $author.name.display | default $author_id -}}

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -22,7 +22,7 @@
         {{ partial "icons/icon" (dict
         "path" "icons/post/author.svg"
         ) }}
-        {{- $author_id := .Site.Params.author.name | default .Site.Author.name -}}
+        {{- $author_id := .Params.author | default .Site.Params.author.name | default .Site.Author.name -}}
         {{- $author := (index ($.Site.Data.authors | default dict) $author_id) -}}
         {{- $author_lang := (index ($author | default dict) .Site.Language.Lang) -}}
         {{- $author_name := $author_lang.name.display | default $author.name.display | default $author_id -}}


### PR DESCRIPTION
Fixes PR #372 which removed individual post author settings. This change maintains multi-author support by allowing author to be specified at the post level rather than only globally.