### PR TITLE
Re-enable author-info styling

### DIFF
--- a/assets/sass/jane.scss
+++ b/assets/sass/jane.scss
@@ -191,7 +191,7 @@ $mobile-breakpoint: 768px !default;
 // @import "_partial/tags";
 // @import "_partial/categories";
 // @import "_partial/back-to-top";
-// @import "_partial/author_info";
+@import "_partial/author_info";
 
 /**------------------------------------------------------------------------
  *                           page styles


### PR DESCRIPTION
Currently if you show the author info, the styling looks not great. Importing the partial style seems to fix the issue. It is not clear if there was a reason that author_info was not imported though.