### PR TITLE
Remove comment link if there are no comments

### DIFF
--- a/layouts/partials/post/meta.html
+++ b/layouts/partials/post/meta.html
@@ -50,11 +50,13 @@
     <span class="post-meta-more">
       {{ i18n "wordCount" .WordCount }} -
       {{ i18n "readingTime" .ReadingTime }}
+      {{ if ne .Params.comment false }}
       {{ if and .Site.Params.commentCount.disqus.enable .Site.GetPage.IsHome }}
       - <a href="{{ .Permalink }}#disqus_thread">{{ i18n "comments" }}</a>
       {{ end }}
       {{- if .Site.Params.commentCount.remark42.enable }}
       - <span class="remark42__counter" data-url="{{ .Permalink }}"></span> {{ i18n "comments" }}
+      {{ end }}
       {{ end -}}
     </span>
     {{- end }}


### PR DESCRIPTION
Currently Jane allows an author to disable the comments on individual articles.. However, the option does not remove the link to the comments. This PR removes the link if the author disables the comments on the specific article.

We use the same condition as:
https://github.com/xianmin/hugo-theme-jane/blob/1e476ccc61156dc87443f7011cd114a64491b4e1/layouts/partials/comments.html#L1