### PR TITLE
Fix Disqus in dark mode

### DIFF
--- a/assets/sass/_partial/_post.scss
+++ b/assets/sass/_partial/_post.scss
@@ -51,4 +51,10 @@
   justify-content: center;
 }
 
+ // This is to match the color scheme of Disqus so that its background could be transparent
+ // See: https://fvsch.com/transparent-iframes
+.comment [id*="disqus"] iframe {
+  color-scheme: light;
+}
+
 @import '_toc';

--- a/layouts/partials/comments/disqus.html
+++ b/layouts/partials/comments/disqus.html
@@ -21,7 +21,7 @@
 
       document.getElementById('load_disqus_container').style.display = 'none';
 
-      // disqus needs to be reloaded when theme is changed
+      // disqus needs to be reloaded when the theme is changed
       const themeToggles = document.querySelectorAll('.theme-toggle');
       themeToggles.forEach(toggle => {
         toggle.addEventListener('click', function (e) {

--- a/layouts/partials/comments/disqus.html
+++ b/layouts/partials/comments/disqus.html
@@ -20,6 +20,21 @@
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 
       document.getElementById('load_disqus_container').style.display = 'none';
+
+      // disqus needs to be reloaded when theme is changed
+      const themeToggles = document.querySelectorAll('.theme-toggle');
+      themeToggles.forEach(toggle => {
+        toggle.addEventListener('click', function (e) {
+          e.preventDefault();
+          DISQUS.reset({
+            reload: true,
+            config: function () {
+              this.page.identifier = '{{ .Site.Config.Services.Disqus.Shortname }}';
+              this.page.url = {{ .Permalink }};
+            }
+          });
+        });
+      });
     };
   </script>
   <noscript>Please enable JavaScript to view the


### PR DESCRIPTION
Closes #412.

This PR fixes the background of the Disqus comments in dark mode.

The issue is that the background of `iframe`s would become opaque if the inherited `color-scheme` is different from the embedded web page.