### PR TITLE
Fix mobile navbar font family

### DIFF
--- a/assets/sass/_partial/_header/_mobile_header.scss
+++ b/assets/sass/_partial/_header/_mobile_header.scss
@@ -15,6 +15,7 @@
     align-items: center;
     font-size: 1.3rem;
     line-height: 1;
+    font-family: $logo-font-family;
 
     .mobile-navbar-icon {
       font-size: 1.5em;


### PR DESCRIPTION
## Description

This PR fixes an issue where the mobile navbar wasn't using the same font family as the desktop header.

### Problem
In version 3 of the theme, the mobile navbar text was missing the `font-family: $logo-font-family;` CSS rule that was present in the desktop header. This caused inconsistent typography between desktop and mobile views.

### Solution
Added the missing CSS rule to `.mobile-navbar` in the mobile header SCSS file.

### Visual comparison
[Screenshots will be attached showing the before and after views]

- v2.png: Desktop header with correct font (reference) <img width="572" alt="v2" src="https://github.com/user-attachments/assets/7ce7a54f-88a1-4c5a-b021-3876d68f24fb" />
- v3.png: Mobile header with incorrect font (before fix) <img width="572" alt="v3" src="https://github.com/user-attachments/assets/7309662e-ce3b-48d9-8de8-5998573d9578" />
- v3-fixed.png: Mobile header with correct font (after fix) <img width="572" alt="v3-fixed" src="https://github.com/user-attachments/assets/b3e3d47f-ae23-4a2b-9613-5a42451ef0d3" />