### PR TITLE
Add .gitignore file to exampleSite directory

### DIFF
--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,0 +1,3 @@
+public/
+resources/_gen/
+assets/jsconfig.json


### PR DESCRIPTION
This PR adds a .gitignore file to the exampleSite directory to exclude public/, resources/_gen/, and assets/jsconfig.json from version control.

Without this, running `cd exampleSite &&  hugo --themesDir=../.. --theme=hugo-theme-jane` leaves a ton of uncommited changes in the git repo.