### PR TITLE
Update Sass import syntax to modern @use and meta.load-css

### DIFF
--- a/assets/sass/_partial/_footer.scss
+++ b/assets/sass/_partial/_footer.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // ==============================
 // Post footer
 // =============================
@@ -8,6 +9,6 @@
   padding-top: 2rem;
   padding-bottom: 1rem;
 
-  @import "_footer/social";
-  @import "_footer/copyright";
+  @include meta.load-css("_footer/social");
+  @include meta.load-css("_footer/copyright");
 }

--- a/assets/sass/_partial/_post/_content.scss
+++ b/assets/sass/_partial/_post/_content.scss
@@ -1,6 +1,7 @@
+@use "sass:meta";
 .post-content {
   // @import "content/highlight";
-  @import "_content/image";
+  @include meta.load-css("_content/image");
 
   @include style-to-mobile {
     h1 {


### PR DESCRIPTION
This PR updates the SASS import syntax to use modern @use and meta.load-css methods as recommended by Sass. These changes were made using the sass-migrator module tool with the --migrate-deps flag.