### PR TITLE
Add GitHub CI workflow for testing theme build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test Hugo Build
+
+on:
+  push:
+    branches:
+    tags:
+    paths_ignored:
+      - "**.md"
+  pull_request:
+    paths_ignored:
+      - "**.md"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.147.1
+    steps:
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Test Build with Hugo
+        run: |
+          cd exampleSite
+          hugo --themesDir=../.. --theme=hugo-theme-jane


### PR DESCRIPTION
# Add GitHub CI test workflow

This PR adds a GitHub Actions workflow that automatically tests the theme build process when:
- Pull requests are opened against any branch
- Changes are pushed to any branch or tag
- Documentation changes (MD files) are ignored

## Changes
- Add `.github/workflows/test.yml` that:
  - Uses Ubuntu latest as the build environment
  - Installs Hugo v0.147.1 (extended version) and Dart Sass
  - Builds the example site using `hugo --themesDir=../.. --theme=hugo-theme-jane`
  - Fails automatically if the build process encounters any errors

## Benefits
- Prevents breaking changes from being merged
- Provides immediate feedback on pull requests
- Ensures the theme always builds successfully