### PR TITLE
Fix Remark42 theme switching

### DIFF
--- a/assets/js/initToggleTheme.js
+++ b/assets/js/initToggleTheme.js
@@ -1,4 +1,4 @@
-// Toogle Theme
+// Toggle Theme
 
 function initThemeToggle() {
   const html = document.documentElement;
@@ -7,6 +7,14 @@ function initThemeToggle() {
   function setTheme(theme) {
     html.setAttribute('data-theme', theme);
     localStorage.setItem('theme', theme);
+
+    if (window.REMARK42 && window.REMARK42.changeTheme) {
+      try {
+        window.REMARK42.changeTheme(theme);
+      } catch (e) {
+        console.error('Failed to update Remark42 theme:', e);
+      }
+    }
   }
 
   function toggleTheme() {

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -230,6 +230,7 @@
   var remark_config = {
     host: '{{ .Site.Params.remark42Url }}',
     site_id: '{{ .Site.Params.remark42SiteId | default "remark" }}',
+    theme: document.documentElement.getAttribute('data-theme') || 'light',
     components: [
 {{- if not .IsHome }}
     'embed',


### PR DESCRIPTION
Summary

This PR fixes the Remark42 comment widget theme switching issue described in #407. It properly synchronizes the Remark42 theme with the site theme by:

1. Setting the initial theme when loading Remark42
2. Updating the Remark42 theme when the site theme is toggled
3. Adding proper error handling and readiness checks

## Demo

https://github.com/user-attachments/assets/6903e337-ad04-4dfa-bf35-73c0758da564

## Technical Details

- Modified `scripts.html` to pass the current theme to Remark42 on initialization
- Updated `initToggleTheme.js` to call Remark42's `changeTheme()` API when site theme changes
- Added checks to ensure Remark42 is properly loaded before attempting to change theme

Fixes #407