### PR TITLE
Make RSS icon and metadata optional via separate configuration flags

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -19,6 +19,7 @@ Jane 是一个专注于阅读体验的 Hugo 主题。最早的版本基于 [hugo
 - 自定义 css，自定义 js，自定义 head
 - 子目录支持
 - 搜索优化
+- 可独立配置页眉 RSS 元数据和页脚 RSS 图标
 
 
 ## 谁在用 Hugo-theme-Jane

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Jane is a readable theme for Hugo. Many color schemes to choose, and easy to per
 - Custom css, Custom js, Custom head support
 - Sub menu support
 - Search Optimization
+- Configurable RSS options with separate controls for header metadata and footer icon
 
 ## Development Philosophy of This Theme
 1. No `node_modules` - fewer dependencies make maintenance easier.

--- a/exampleSite/full-config.toml
+++ b/exampleSite/full-config.toml
@@ -91,6 +91,11 @@ defaultContentLanguage = "en"           # Default language to use
   # wallpaper = "/static/img/wallpaper.jpg"
   wallpaper = "https://followingmyfeet.com/wp-content/uploads/2018/02/825_2229-HDR.jpg"
 
+  # Show or hide RSS icon in footer
+  showRSSIconInFooter = true
+  # Show or hide RSS metadata in header
+  showRSSIconInHeader = true
+
   # 一些全局开关，你也可以在每一篇内容的 front matter 中针对单篇内容关闭或开启某些功能，在 archetypes/default.md 查看更多信息。
   # Some global options, you can also close or open something in front matter for a single post, see more information from `archetypes/default.md`.
   toc = true                                                                            # 是否开启目录

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -71,6 +71,11 @@ defaultContentLanguage = "en"           # Default language to use
   photoswipe = true         # see https://github.com/dimsemenov/PhotoSwipe            # 是否启用PhotoSwipe（图片可点击）
   contentCopyright = '<a rel="license noopener" href="https://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank">CC BY-NC-ND 4.0</a>'
 
+  # Show or hide RSS icon in footer
+  showRSSIconInFooter = true
+  # Show or hide RSS metadata in header
+  showRSSIconInHeader = true
+
   # Link custom CSS and JS assets
   #   (relative to /static/css and /static/js respectively)
   customCSS = []            # if ['custom.css'], load '/static/css/custom.css' file

--- a/layouts/partials/head/head_rss.html
+++ b/layouts/partials/head/head_rss.html
@@ -1,7 +1,9 @@
 <!-- Permalink & RSSlink -->
 <link rel="canonical" href="{{ .Permalink }}" />
+{{ if not (eq .Site.Params.showRSSIconInHeader false) }}
 {{ with .OutputFormats.Get "RSS" }}
 <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />{{ end }}
+{{ end }}
 
 {{ if .OutputFormats.Get "jsonfeed" }}
 <link href="{{ with .OutputFormats.Get `jsonfeed` }}{{ .Permalink }}{{ end }}" rel="alternate" type="application/json"

--- a/layouts/partials/social_links.html
+++ b/layouts/partials/social_links.html
@@ -25,6 +25,7 @@
 {{- end }}
 
 {{/* RSS icon */}}
+{{ if not (eq .Site.Params.showRSSIconInFooter false) }}
 {{ with .Site.GetPage "home" -}}
 {{- with .OutputFormats.Get "RSS" -}}
 <a href="{{ .Permalink }}" rel="noopener {{ .Rel }}" type="{{ .MediaType.Type }}" class="social-icon-link" title="rss"
@@ -35,3 +36,4 @@
 </a>
 {{ end -}}
 {{- end -}}
+{{ end }}


### PR DESCRIPTION
## Summary

- Added separate configuration options for RSS:
  - `showRSSIconInHeader` controls the RSS metadata in the page header
  - `showRSSIconInFooter` controls the RSS icon in the footer
- Both options default to true for backward compatibility
- Updated documentation in both English and Chinese READMEs

Fixes #361